### PR TITLE
feat(strings): add some strings impl and docs

### DIFF
--- a/src/internals/strings/Strings.ts
+++ b/src/internals/strings/Strings.ts
@@ -1,7 +1,8 @@
-import { Fn } from "../core/Core";
+import { Call, Fn } from "../core/Core";
 import { Std } from "../std/Std";
 import { Tuples } from "../tuples/Tuples";
 import * as H from "../../helpers";
+import * as Impl from "./impl/strings";
 
 export namespace Strings {
   export type Stringifiable =
@@ -21,56 +22,249 @@ export namespace Strings {
       : never;
   }
 
+  /**
+   * Get the length of a string.
+   * @param args[0] - The string to get the length of.
+   * @returns The length of the string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.Length,"abc">; // 3
+   * ```
+   */
+  export interface Length extends Fn {
+    output: Impl.StringToTuple<this["args"][0]>["length"];
+  }
+
+  /**
+   * Trim the left side of a string.
+   * @param args[0] - The string to trim.
+   * @param Sep - The separator to trim.
+   * @returns The trimmed string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.TrimLeft,"  abc">; // "abc"
+   * ```
+   */
+  export interface TrimLeft<Sep extends string = " "> extends Fn {
+    output: Impl.TrimLeft<this["args"][0], Sep>;
+  }
+
+  /**
+   * Trim the right side of a string.
+   * @param args[0] - The string to trim.
+   * @param Sep - The separator to trim.
+   * @returns The trimmed string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.TrimRight,"abc  ">; // "abc"
+   * ```
+   */
+  export interface TrimRight<Sep extends string = " "> extends Fn {
+    output: Impl.TrimRight<this["args"][0], Sep>;
+  }
+
+  /**
+   * Trim a string.
+   * @param args[0] - The string to trim.
+   * @param Sep - The separator to trim.
+   * @returns The trimmed string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.Trim,"  abc  ">; // "abc"
+   * ```
+   */
+  export interface Trim<Sep extends string = " "> extends Fn {
+    output: Impl.Trim<this["args"][0], Sep>;
+  }
+
+  /**
+   * Join a tuple of strings into a single string.
+   * @param args[0] - The tuple of strings to join.
+   * @param sep - The separator to join the strings with.
+   * @returns The joined string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.Join<",">,["a","b","c"]>; // "a,b,c"
+   * ```
+   */
   export interface Join<sep extends string> extends Fn {
     output: Tuples.ReduceImpl<this["args"][0], "", JoinReducer<sep>>;
   }
 
+  /**
+   * Split a string into a tuple of strings.
+   * @param args[0] - The string to split.
+   * @param sep - The separator to split the string with.
+   * @returns The split string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.Split<",">,"a,b,c">; // ["a","b","c"]
+   * ```
+   */
   export interface Split<sep extends string> extends Fn {
-    output: H.Split<this["args"][0], sep>;
+    output: Impl.Split<this["args"][0], sep>;
   }
 
+  /**
+   * Split a string into a tuple of each character.
+   * @param args[0] - The string to split.
+   * @returns The splited string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.ToTuple,"abc">; // ["a","b","c"]
+   */
+  export interface ToTuple extends Fn {
+    output: Impl.StringToTuple<this["args"][0]>;
+  }
+
+  /**
+   * Convert a string to a number or bigint.
+   * @param args[0] - The string to convert.
+   * @returns The converted number or bigint.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.ToNumber,"123">; // 123
+   * type T1 = Call<Strings.ToNumber,"12367543547677078675456656790">; // 12367543547677078675456656790n
+   * ```
+   */
   export interface ToNumber extends Fn {
     output: this["args"][0] extends `${infer n extends number | bigint}`
       ? n
       : never;
   }
 
+  /**
+   * Convert a stringifiable literal to a string.
+   * @param args[0] - The stringifiable literal to convert.
+   * @returns The converted string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.ToString,123>; // "123"
+   * type T1 = Call<Strings.ToString,true>; // "true"
+   * type T2 = Call<Strings.ToString,null>; // "null"
+   * ```
+   */
   export interface ToString extends Fn {
     output: `${Extract<this["args"][0], Strings.Stringifiable>}`;
   }
 
+  /**
+   * Prepend a string to another string.
+   * @param args[0] - The string to be prepended to.
+   * @param str - The string to prepend.
+   * @returns The prepended string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.Prepend<"abc">,"def">; // "abcdef"
+   * ```
+   */
   export interface Prepend<str extends string> extends Fn {
     output: `${str}${Extract<this["args"][0], Strings.Stringifiable>}`;
   }
 
+  /**
+   * Append a string to another string.
+   * @param args[0] - The string to be appended to.
+   * @param str - The string to append.
+   * @returns The appended string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.Append<"abc">,"def">; // "defabc"
+   * ```
+   */
   export interface Append<str extends string> extends Fn {
     output: `${Extract<this["args"][0], Strings.Stringifiable>}${str}`;
   }
 
+  /**
+   * Transform a string to uppercase.
+   * @param args[0] - The string to transform.
+   * @returns The transformed string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.Uppercase,"abc">; // "ABC"
+   * ```
+   */
   export interface Uppercase extends Fn {
     output: Std._Uppercase<Extract<this["args"][0], string>>;
   }
 
+  /**
+   * Transform a string to lowercase.
+   * @param args[0] - The string to transform.
+   * @returns The transformed string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.Lowercase,"ABC">; // "abc"
+   * ```
+   */
   export interface Lowercase extends Fn {
     output: Std._Lowercase<Extract<this["args"][0], string>>;
   }
 
+  /**
+   * Capitalize a string.
+   * @param args[0] - The string to capitalize.
+   * @returns The capitalized string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.Capitalize,"abc">; // "Abc"
+   * ```
+   */
   export interface Capitalize extends Fn {
     output: Std._Capitalize<Extract<this["args"][0], string>>;
   }
 
+  /**
+   * Uncapitalize a string.
+   * @param args[0] - The string to uncapitalize.
+   * @returns The uncapitalized string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.Uncapitalize,"AddTop">; // "addTop"
+   * ```
+   */
   export interface Uncapitalize extends Fn {
     output: Std._Uncapitalize<Extract<this["args"][0], string>>;
   }
 
+  /**
+   * Convert a string to snake case.
+   * @param args[0] - The string to convert.
+   * @returns The converted string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.SnakeCase,"AddTop">; // "add_top"
+   * ```
+   */
   export interface SnakeCase extends Fn {
     output: H.SnakeCase<this["args"][0]>;
   }
 
+  /**
+   * Convert a string to camel case.
+   * @param args[0] - The string to convert.
+   * @returns The converted string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.CamelCase,"add_top">; // "addTop"
+   * ```
+   */
   export interface CamelCase extends Fn {
     output: H.CamelCase<this["args"][0]>;
   }
 
+  /**
+   * Convert a string to kebab case.
+   * @param args[0] - The string to convert.
+   * @returns The converted string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.KebabCase,"add_top">; // "add-top"
+   * type T1 = Call<Strings.KebabCase,"AddTop">; // "add-top"
+   * type T2 = Call<Strings.KebabCase,"addTop">; // "add-top"
+   * ```
+   */
   export interface KebabCase extends Fn {
     output: H.KebabCase<this["args"][0]>;
   }

--- a/src/internals/strings/Strings.ts
+++ b/src/internals/strings/Strings.ts
@@ -1,4 +1,4 @@
-import { Call, Fn } from "../core/Core";
+import { Call, Call2, Fn, MergeArgs, Pipe, placeholder } from "../core/Core";
 import { Std } from "../std/Std";
 import { Tuples } from "../tuples/Tuples";
 import * as H from "../../helpers";
@@ -92,6 +92,37 @@ export namespace Strings {
   }
 
   /**
+   * Replace all instances of a substring in a string.
+   * @param args[0] - The string to replace.
+   * @param from - The substring to replace.
+   * @param to - The substring to replace with.
+   * @returns The replaced string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.Replace<".","/">,"a.b.c.d">; // "a/b/c/d"
+   */
+  export interface Replace<from extends string, to extends string> extends Fn {
+    output: Impl.Replace<this["args"][0], from, to>;
+  }
+
+  /**
+   * Cut a slice of a string out from a start index to an end index.
+   * @param args[0] - The string to slice.
+   * @param start - The start index.
+   * @param end - The end index.
+   * @returns The sliced string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.Slice<1,9>,"1234567890">; // "23456789"
+   */
+  export interface Slice<start extends number, end extends number> extends Fn {
+    output: Pipe<
+      Impl.StringToTuple<this["args"][0]>,
+      [Tuples.Take<end>, Tuples.Drop<start>, Join<"">]
+    >;
+  }
+
+  /**
    * Split a string into a tuple of strings.
    * @param args[0] - The string to split.
    * @param sep - The separator to split the string with.
@@ -103,6 +134,50 @@ export namespace Strings {
    */
   export interface Split<sep extends string> extends Fn {
     output: Impl.Split<this["args"][0], sep>;
+  }
+
+  /**
+   * Repeat a string a number of times.
+   * @param args[0] - The string to repeat.
+   * @param times - The number of times to repeat the string.
+   * @returns The repeated string.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.Repeat<3>,"Hello! ">; // "Hello! Hello! Hello! "
+   * ```
+   */
+  export interface Repeat<times extends number> extends Fn {
+    output: Impl.Repeat<this["args"][0], H.Iterator.Iterator<times>>;
+  }
+
+  /**
+   * Check if a string starts with a substring.
+   * @param args[0] - The string to check.
+   * @param str - The substring to check for.
+   * @returns Whether the string starts with the substring.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.StartsWith<"abc">,"abcdef">; // true
+   * type T1 = Call<Strings.StartsWith<"abc">,"defabc">; // false
+   * ```
+   */
+  export interface StartsWith<str extends string> extends Fn {
+    output: this["args"][0] extends `${str}${string}` ? true : false;
+  }
+
+  /**
+   * Check if a string ends with a substring.
+   * @param args[0] - The string to check.
+   * @param str - The substring to check for.
+   * @returns Whether the string ends with the substring.
+   * @example
+   * ```ts
+   * type T0 = Call<Strings.EndsWith<"abc">,"abcdef">; // false
+   * type T1 = Call<Strings.EndsWith<"abc">,"defabc">; // true
+   * ```
+   */
+  export interface EndsWith<str extends string> extends Fn {
+    output: this["args"][0] extends `${string}${str}` ? true : false;
   }
 
   /**
@@ -267,5 +342,192 @@ export namespace Strings {
    */
   export interface KebabCase extends Fn {
     output: H.KebabCase<this["args"][0]>;
+  }
+
+  /**
+   * Compare two strings. (only works with ascii extended characters)
+   * @param args[0] - The first string to compare.
+   * @param args[1] - The second string to compare.
+   * @n1 - The first string to compare or placeholder.
+   * @n2 - The second string to compare or placeholder.
+   * @returns The result of the comparison.
+   * @example
+   * ```ts
+   * type T0 = Call2<Strings.Compare,"abc","def">; // -1
+   * type T1 = Call2<Strings.Compare,"def","abc">; // 1
+   * type T2 = Call2<Strings.Compare,"abc","abc">; // 0
+   * ```
+   */
+  export interface Compare<
+    n1 extends string | placeholder = placeholder,
+    n2 extends string | placeholder = placeholder
+  > extends Fn {
+    output: MergeArgs<this["args"], [n1, n2]> extends [
+      infer a extends string,
+      infer b extends string,
+      ...any
+    ]
+      ? Impl.Compare<a, b>
+      : never;
+  }
+
+  /**
+   * Check if two strings are equal. (only works with ascii extended characters)
+   * @param args[0] - The first string to compare.
+   * @param args[1] - The second string to compare.
+   * @n1 - The first string to compare or placeholder.
+   * @n2 - The second string to compare or placeholder.
+   * @returns True if the strings are equal, false otherwise.
+   * @example
+   * ```ts
+   * type T0 = Call2<Strings.Equal,"abc","def">; // false
+   * type T1 = Call2<Strings.Equal,"def","abc">; // false
+   * type T2 = Call2<Strings.Equal,"abc","abc">; // true
+   */
+  export interface Equal<
+    n1 extends string | placeholder = placeholder,
+    n2 extends string | placeholder = placeholder
+  > extends Fn {
+    output: MergeArgs<this["args"], [n1, n2]> extends [
+      infer a extends string,
+      infer b extends string,
+      ...any
+    ]
+      ? Impl.Equal<a, b>
+      : never;
+  }
+
+  /**
+   * Check if two strings are not equal. (only works with ascii extended characters)
+   * @param args[0] - The first string to compare.
+   * @param args[1] - The second string to compare.
+   * @n1 - The first string to compare or placeholder.
+   * @n2 - The second string to compare or placeholder.
+   * @returns True if the strings are not equal, false otherwise.
+   * @example
+   * ```ts
+   * type T0 = Call2<Strings.NotEqual,"abc","def">; // true
+   * type T1 = Call2<Strings.NotEqual,"def","abc">; // true
+   * type T2 = Call2<Strings.NotEqual,"abc","abc">; // false
+   * ```
+   */
+  export interface NotEqual<
+    n1 extends string | placeholder = placeholder,
+    n2 extends string | placeholder = placeholder
+  > extends Fn {
+    output: MergeArgs<this["args"], [n1, n2]> extends [
+      infer a extends string,
+      infer b extends string,
+      ...any
+    ]
+      ? Impl.NotEqual<a, b>
+      : never;
+  }
+
+  /**
+   * Check if a string is lexically less than another string. (only works with ascii extended characters)
+   * @param args[0] - The first string to compare.
+   * @param args[1] - The second string to compare.
+   * @n1 - The first string to compare or placeholder.
+   * @n2 - The second string to compare or placeholder.
+   * @returns True if the first string is lexically less than the second string, false otherwise.
+   * @example
+   * ```ts
+   * type T0 = Call2<Strings.LessThan,"abc","def">; // true
+   * type T1 = Call2<Strings.LessThan,"def","abc">; // false
+   * type T2 = Call2<Strings.LessThan,"abc","abc">; // false
+   * ```
+   */
+  export interface LessThan<
+    n1 extends string | placeholder = placeholder,
+    n2 extends string | placeholder = placeholder
+  > extends Fn {
+    output: MergeArgs<this["args"], [n1, n2]> extends [
+      infer a extends string,
+      infer b extends string,
+      ...any
+    ]
+      ? Impl.LessThan<a, b>
+      : never;
+  }
+
+  /**
+   * Check if a string is lexically less than or equal to another string. (only works with ascii extended characters)
+   * @param args[0] - The first string to compare.
+   * @param args[1] - The second string to compare.
+   * @n1 - The first string to compare or placeholder.
+   * @n2 - The second string to compare or placeholder.
+   * @returns True if the first string is lexically less than or equal to the second string, false otherwise.
+   * @example
+   * ```ts
+   * type T0 = Call2<Strings.LessThanOrEqual,"abc","def">; // true
+   * type T1 = Call2<Strings.LessThanOrEqual,"def","abc">; // false
+   * type T2 = Call2<Strings.LessThanOrEqual,"abc","abc">; // true
+   */
+  export interface LessThanOrEqual<
+    n1 extends string | placeholder = placeholder,
+    n2 extends string | placeholder = placeholder
+  > extends Fn {
+    output: MergeArgs<this["args"], [n1, n2]> extends [
+      infer a extends string,
+      infer b extends string,
+      ...any
+    ]
+      ? Impl.LessThanOrEqual<a, b>
+      : never;
+  }
+
+  /**
+   * Check if a string is lexically greater than another string. (only works with ascii extended characters)
+   * @param args[0] - The first string to compare.
+   * @param args[1] - The second string to compare.
+   * @n1 - The first string to compare or placeholder.
+   * @n2 - The second string to compare or placeholder.
+   * @returns True if the first string is lexically greater than the second string, false otherwise.
+   * @example
+   * ```ts
+   * type T0 = Call2<Strings.GreaterThan,"abc","def">; // false
+   * type T1 = Call2<Strings.GreaterThan,"def","abc">; // true
+   * type T2 = Call2<Strings.GreaterThan,"abc","abc">; // false
+   * ```
+   */
+  export interface GreaterThan<
+    n1 extends string | placeholder = placeholder,
+    n2 extends string | placeholder = placeholder
+  > extends Fn {
+    output: MergeArgs<this["args"], [n1, n2]> extends [
+      infer a extends string,
+      infer b extends string,
+      ...any
+    ]
+      ? Impl.GreaterThan<a, b>
+      : never;
+  }
+
+  /**
+   * Check if a string is lexically greater than or equal to another string. (only works with ascii extended characters)
+   * @param args[0] - The first string to compare.
+   * @param args[1] - The second string to compare.
+   * @n1 - The first string to compare or placeholder.
+   * @n2 - The second string to compare or placeholder.
+   * @returns True if the first string is lexically greater than or equal to the second string, false otherwise.
+   * @example
+   * ```ts
+   * type T0 = Call2<Strings.GreaterThanOrEqual,"abc","def">; // false
+   * type T1 = Call2<Strings.GreaterThanOrEqual,"def","abc">; // true
+   * type T2 = Call2<Strings.GreaterThanOrEqual,"abc","abc">; // true
+   * ```
+   */
+  export interface GreaterThanOrEqual<
+    n1 extends string | placeholder = placeholder,
+    n2 extends string | placeholder = placeholder
+  > extends Fn {
+    output: MergeArgs<this["args"], [n1, n2]> extends [
+      infer a extends string,
+      infer b extends string,
+      ...any
+    ]
+      ? Impl.GreaterThanOrEqual<a, b>
+      : never;
   }
 }

--- a/src/internals/strings/impl/compare.ts
+++ b/src/internals/strings/impl/compare.ts
@@ -1,0 +1,98 @@
+import { Call, Call2 } from "../../core/Core";
+import { Numbers } from "../../numbers/Numbers";
+import { StringToTuple } from "./split";
+
+// prettier-ignore
+type ascii = {
+  " ": 32; "!": 33; '"': 34; "#": 35; $: 36; "%": 37; "&": 38; "'": 39;
+  "(": 40; ")": 41; "*": 42; "+": 43; ",": 44; "-": 45; ".": 46; "/": 47; "0": 48; "1": 49;
+  "2": 50; "3": 51; "4": 52; "5": 53; "6": 54; "7": 55; "8": 56; "9": 57; ":": 58; ";": 59;
+  "<": 60; "=": 61; ">": 62; "?": 63; "@": 64; A: 65; B: 66; C: 67; D: 68; E: 69;
+  F: 70; G: 71; H: 72; I: 73; J: 74; K: 75; L: 76; M: 77; N: 78; O: 79;
+  P: 80; Q: 81; R: 82; S: 83; T: 84; U: 85; V: 86; W: 87; X: 88; Y: 89;
+  Z: 90; "[": 91; "\\": 92; "]": 93; "^": 94; _: 95; "`": 96; a: 97; b: 98; c: 99;
+  d: 100; e: 101; f: 102; g: 103; h: 104; i: 105; j: 106; k: 107; l: 108; m: 109;
+  n: 110; o: 111; p: 112; q: 113; r: 114; s: 115; t: 116; u: 117; v: 118; w: 119;
+  x: 120; y: 121; z: 122; "{": 123; "|": 124; "}": 125; "~": 126;
+  é: 130; â: 131; ä: 132; à: 133; å: 134; ç: 135; ê: 136; ë: 137; è: 138; ï: 139;
+  î: 140; ì: 141; Ä: 142; Å: 143; É: 144; æ: 145; Æ: 146; ô: 147; ö: 148; ò: 149;
+  û: 150; ù: 151; ÿ: 152; Ö: 153; Ü: 154; ø: 155; "£": 156; Ø: 157; "×": 158; ƒ: 159;
+  á: 160; í: 161; ó: 162; ú: 163; ñ: 164; Ñ: 165; ª: 166; º: 167; "¿": 168; "®": 169;
+  "½": 171; "¼": 172; "¡": 173; "«": 174; "»": 175; "░": 176; "▒": 177; "▓": 178; "│": 179;
+  "┤": 180; Á: 181; Â: 182; À: 183; "©": 184; "╣": 185; "║": 186; "╗": 187; "╝": 188; "¢": 189;
+  "¥": 190; "┐": 191; "└": 192; "┴": 193; "┬": 194; "├": 195; "─": 196; "┼": 197; ã: 198; Ã: 199;
+  "╚": 200; "╔": 201; "╩": 202; "╦": 203; "╠": 204; "═": 205; "╬": 206; "¤": 207; ð: 208; Ð: 209;
+  Ê: 210; Ë: 211; È: 212; ı: 213; Í: 214; Î: 215; Ï: 216; "┘": 217; "┌": 218; "█": 219;
+  "▄": 220; "¦": 221; Ì: 222; "▀": 223; Ó: 224; ß: 225; Ô: 226; Ò: 227; õ: 228; Õ: 229;
+  µ: 230; þ: 231; Þ: 232; Ú: 233; Û: 234; Ù: 235; ý: 236; Ý: 237; "¯": 238; "´": 239;
+  "¬": 240; "±": 241; "‗": 242; "¾": 243; "¶": 244; "§": 245; "÷": 246; "¸": 247; "°": 248; "¨": 249;
+  "•": 250; "¹": 251; "³": 252; "²": 253; "■": 254;
+};
+
+type CharacterCompare<
+  Char1 extends string,
+  Char2 extends string
+> = Char1 extends Char2
+  ? 0
+  : Char1 extends keyof ascii
+  ? Char2 extends keyof ascii
+    ? Call2<Numbers.Compare, ascii[Char1], ascii[Char2]>
+    : 1
+  : -1;
+
+type CharactersCompare<T extends string[], U extends string[]> = T extends [
+  infer N1 extends string,
+  ...infer R1 extends string[]
+]
+  ? U extends [infer N2 extends string, ...infer R2 extends string[]]
+    ? CharacterCompare<N1, N2> extends 0
+      ? CharactersCompare<R1, R2>
+      : CharacterCompare<N1, N2>
+    : 1
+  : U extends [string, ...string[]]
+  ? -1
+  : 0;
+
+export type Compare<T extends string, U extends string> = CharactersCompare<
+  StringToTuple<T>,
+  StringToTuple<U>
+>;
+
+export type LessThan<T extends string, U extends string> = Compare<
+  T,
+  U
+> extends -1
+  ? true
+  : false;
+
+export type LessThanOrEqual<T extends string, U extends string> = Compare<
+  T,
+  U
+> extends 1
+  ? false
+  : true;
+
+export type Equal<T extends string, U extends string> = Compare<T, U> extends 0
+  ? true
+  : false;
+
+export type NotEqual<T extends string, U extends string> = Compare<
+  T,
+  U
+> extends 0
+  ? false
+  : true;
+
+export type GreaterThan<T extends string, U extends string> = Compare<
+  T,
+  U
+> extends 1
+  ? true
+  : false;
+
+export type GreaterThanOrEqual<T extends string, U extends string> = Compare<
+  T,
+  U
+> extends -1
+  ? false
+  : true;

--- a/src/internals/strings/impl/repeat.ts
+++ b/src/internals/strings/impl/repeat.ts
@@ -1,0 +1,11 @@
+import * as H from "../../../helpers";
+
+export type Repeat<
+  str,
+  n extends any[],
+  acc extends string = ""
+> = H.Iterator.Get<n> extends 0
+  ? acc
+  : str extends string
+  ? Repeat<str, H.Iterator.Prev<n>, `${str}${acc}`>
+  : never;

--- a/src/internals/strings/impl/replace.ts
+++ b/src/internals/strings/impl/replace.ts
@@ -1,0 +1,9 @@
+export type Replace<
+  Str,
+  From extends string,
+  To extends string
+> = Str extends string
+  ? Str extends `${infer Before}${From}${infer After}`
+    ? Replace<`${Before}${To}${After}`, From, To>
+    : Str
+  : Str;

--- a/src/internals/strings/impl/split.ts
+++ b/src/internals/strings/impl/split.ts
@@ -1,0 +1,47 @@
+import * as H from "../../../helpers";
+
+type ConcatSplits<
+  Parts extends string[],
+  Seps extends string[],
+  Acc extends string[] = []
+> = Parts extends [infer First extends string, ...infer Rest extends string[]]
+  ? ConcatSplits<Rest, Seps, [...Acc, ...SplitManySep<First, Seps>]>
+  : Acc;
+
+type SplitManySep<
+  Str extends string,
+  Sep extends string[],
+  Acc extends string[] = []
+> = Sep extends [
+  infer FirstSep extends string,
+  ...infer RestSep extends string[]
+]
+  ? ConcatSplits<H.Split<Str, FirstSep>, RestSep>
+  : [Str, ...Acc];
+
+/**
+ * Split a string into a tuple.
+ * @param Str - The string to split.
+ * @param Sep - The separator to split on, can be a union of strings of more than one character.
+ * @returns The tuple of each split. if sep is an empty string, returns a tuple of each character.
+ */
+export type Split<
+  Str,
+  Sep extends string,
+  Seps = H.UnionToTuple<Sep>
+> = Seps extends string[]
+  ? Str extends string
+    ? SplitManySep<Str, Seps>
+    : []
+  : [];
+
+/**
+ * Split a string into a tuple with each character.
+ * @param Str - The string to split.
+ * @returns The tuple of each character.
+ */
+export type StringToTuple<Str, Acc extends string[] = []> = Str extends string
+  ? Str extends `${infer First}${infer Rest}`
+    ? StringToTuple<Rest, [...Acc, First]>
+    : Acc
+  : [];

--- a/src/internals/strings/impl/strings.ts
+++ b/src/internals/strings/impl/strings.ts
@@ -1,0 +1,2 @@
+export * from "./split";
+export * from "./trim";

--- a/src/internals/strings/impl/strings.ts
+++ b/src/internals/strings/impl/strings.ts
@@ -1,2 +1,5 @@
 export * from "./split";
 export * from "./trim";
+export * from "./replace";
+export * from "./repeat";
+export * from "./compare";

--- a/src/internals/strings/impl/trim.ts
+++ b/src/internals/strings/impl/trim.ts
@@ -1,0 +1,29 @@
+/**
+ * Trim the left side of a string.
+ * @param Str - The string to trim.
+ * @param Sep - The separator to trim.
+ * @returns The trimmed string.
+ */
+export type TrimLeft<
+  Str,
+  Sep extends string
+> = Str extends `${Sep}${infer Rest}` ? TrimLeft<Rest, Sep> : Str;
+
+/**
+ * Trim the right side of a string.
+ * @param Str - The string to trim.
+ * @param Sep - The separator to trim.
+ * @returns The trimmed string.
+ */
+export type TrimRight<
+  Str,
+  Sep extends string
+> = Str extends `${infer Rest}${Sep}` ? TrimRight<Rest, Sep> : Str;
+
+/**
+ * Trim a string.
+ * @param Str - The string to trim.
+ * @param Sep - The separator to trim.
+ * @returns The trimmed string.
+ */
+export type Trim<Str, Sep extends string> = TrimLeft<TrimRight<Str, Sep>, Sep>;

--- a/test/HOTScript.test.ts
+++ b/test/HOTScript.test.ts
@@ -1035,6 +1035,15 @@ describe("HOTScript", () => {
       type res1 = Call<Strings.Split<".">, "1.2.3">;
       //    ^?
       type test1 = Expect<Equal<res1, ["1", "2", "3"]>>;
+      type res2 = Call<Strings.Split<"">, "123">;
+      //    ^?
+      type test2 = Expect<Equal<res2, ["1", "2", "3"]>>;
+      type res3 = Call<Strings.Split<"">, "">;
+      //    ^?
+      type test3 = Expect<Equal<res3, []>>;
+      type res4 = Call<Strings.Split<"--" | ".">, "1--2-3.4..5">;
+      //    ^?
+      type test4 = Expect<Equal<res4, ["1", "2-3", "4", "5"]>>;
     });
 
     it("ToNumber", () => {


### PR DESCRIPTION
- add some inlined docs for strings to improve DX
- improved `Split` that allows for :  
  - more than one character `seperator`
  - empty separator will split correctly each character
  - unions of seprators still work
- new functions : 
  - TrimLeft
  - TrimRight
  - Trim
  - Length
  - ToTuple
  - Replace
  - Slice
  - Repeat
  - StartsWith
  - EndsWith
  - Compare (only ascii)
  - LessThan
  - LessThanOrEqual
  - GreaterThan
  - GreaterThanOrEqual