### PR TITLE
feat(tuples): make sort generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ type T = {
   - [x] PipeRight
   - [x] Call
   - [x] Apply
-  - [x] Bind
+  - [x] PartialApply
   - [x] Compose
   - [x] ComposeLeft
 - [ ] Tuples

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ type T = {
   - [x] PipeRight
   - [x] Call
   - [x] Apply
-  - [x] ApplyPartial
+  - [x] Bind
   - [x] Compose
   - [x] ComposeLeft
 - [ ] Tuples

--- a/src/internals/functions/Functions.ts
+++ b/src/internals/functions/Functions.ts
@@ -5,7 +5,8 @@ export namespace Functions {
     output: this["args"][0];
   }
 
-  export interface Bind<fn extends Fn, partialArgs extends any[]> extends Fn {
+  export interface PartialApply<fn extends Fn, partialArgs extends any[]>
+    extends Fn {
     output: Apply<fn, MergeArgs<this["args"], partialArgs>>;
   }
 

--- a/src/internals/functions/Functions.ts
+++ b/src/internals/functions/Functions.ts
@@ -5,15 +5,9 @@ export namespace Functions {
     output: this["args"][0];
   }
 
-  interface PipeableApplyPartial<fn extends Fn, partialArgs extends any[]>
-    extends Fn {
+  export interface Bind<fn extends Fn, partialArgs extends any[]> extends Fn {
     output: Apply<fn, MergeArgs<this["args"], partialArgs>>;
   }
-
-  export type ApplyPartial<
-    fn extends Fn,
-    args extends any[]
-  > = PipeableApplyPartial<fn, args>;
 
   type ParametersImpl<fn> = fn extends (...args: infer args) => any
     ? args

--- a/src/internals/tuples/Tuples.ts
+++ b/src/internals/tuples/Tuples.ts
@@ -8,18 +8,51 @@ import { Iterator, Stringifiable } from "../helpers";
 export namespace Tuples {
   type HeadImpl<xs> = xs extends readonly [infer head, ...any] ? head : never;
 
+  /**
+   * Returns the first element of a tuple.
+   * @params args[0] - A tuple.
+   * @return The first element of a tuple.
+   * @example
+   * ```ts
+   * type T0 = Call<T.Head,[1, 2, 3]>; // 1
+   * type T1 = Call<T.Head,[]>; // never
+   * type T2 = Call<T.Head,[1]>; // 1
+   * ```
+   */
   export interface Head extends Fn {
     output: HeadImpl<this["args"][0]>;
   }
 
-  type TailImpl<xs> = xs extends readonly [any, ...infer tail] ? tail : never;
+  type TailImpl<xs> = xs extends readonly [any, ...infer tail] ? tail : [];
 
+  /**
+   * Returns a tuple with all elements except the first.
+   * @params args[0] - A tuple.
+   * @return A tuple with all elements except the first.
+   * @example
+   * ```ts
+   * type T0 = Call<T.Tail,[1, 2, 3]>; // [2, 3]
+   * type T1 = Call<T.Tail,[]>; // []
+   * type T2 = Call<T.Tail,[1]>; // []
+   * ```
+   */
   export interface Tail extends Fn {
     output: TailImpl<this["args"][0]>;
   }
 
   type LastImpl<xs> = xs extends readonly [...any, infer last] ? last : never;
 
+  /**
+   * Returns the last element of a tuple.
+   * @params args[0] - A tuple.
+   * @return The last element of a tuple.
+   * @example
+   * ```ts
+   * type T0 = Call<T.Last,[1, 2, 3]>; // 3
+   * type T1 = Call<T.Last,[]>; // never
+   * type T2 = Call<T.Last,[1]>; // 1
+   * ```
+   */
   export interface Last extends Fn {
     output: LastImpl<this["args"][0]>;
   }
@@ -30,6 +63,17 @@ export namespace Tuples {
       : never;
   }
 
+  /**
+   * Apply a function to each element of a tuple and return a new tuple with the results.
+   * @params args[0] - A tuple of elements to be transformed.
+   * @param fn - A function that takes an element of the tuple and transforms it.
+   * @returns A tuple with the results of applying the function to each element of the input tuple.
+   * @example
+   * ```ts
+   * type T0 = Call<T.Map<S.ToString>,[1,2,3]>; // ["1","2","3"]
+   * type T1 = Call<T.Map<S.ToString>,[]>; // []
+   * ```
+   */
   export interface Map<fn extends Fn> extends Fn {
     output: ReduceImpl<this["args"][0], [], MapFn<fn>>;
   }
@@ -40,6 +84,17 @@ export namespace Tuples {
       : never;
   }
 
+  /**
+   * Apply a function to each element of a tuple and return a new tuple with the results flattened by one level.
+   * @params args[0] - A tuple of elements to be transformed.
+   * @param fn - A function that takes an element of the tuple and transforms it.
+   * @returns A tuple with the results of applying the function to each element of the input tuple flattened by one level.
+   * @example
+   * ```ts
+   * type T0 = Call<T.FlatMapFn<S.ToTuple>,["hello","world"]>; // ["h","e","l","l","o","w","o","r","l","d"]
+   * type T1 = Call<T.FlatMapFn<S.ToTuple>,[]>; // []
+   * ```
+   */
   export interface FlatMap<fn extends Fn> extends Fn {
     output: ReduceImpl<this["args"][0], [], FlatMapFn<fn>>;
   }
@@ -51,6 +106,18 @@ export namespace Tuples {
     ? ReduceImpl<rest, Call2<fn, acc, first>, fn>
     : acc;
 
+  /**
+   * Apply a reducer function to each element of a tuple starting from the first and return the accumulated result.
+   * @params args[0] - A tuple of elements to be transformed.
+   * @params fn - A reducer function that takes the accumulated result and the current element and returns a new accumulated result.
+   * @params init - The initial value of the accumulated result.
+   * @returns The accumulated result.
+   * @example
+   * ```ts
+   * type T0 = Call<T.Reduce<N.Add,0>,[1,2,3]>; // 6
+   * type T1 = Call<T.Reduce<N.Add,0>,[]>; // 0
+   * ```
+   */
   export interface Reduce<fn extends Fn, init> extends Fn {
     output: ReduceImpl<this["args"][0], init, fn>;
   }
@@ -62,6 +129,18 @@ export namespace Tuples {
     ? ReduceRightImpl<rest, Call2<fn, acc, last>, fn>
     : acc;
 
+  /**
+   * Apply a reducer function to each element of a tuple starting from the last and return the accumulated result.
+   * @params args[0] - A tuple of elements to be transformed.
+   * @params fn - A reducer function that takes the accumulated result and the current element and returns a new accumulated result.
+   * @params init - The initial value of the accumulated result.
+   * @returns The accumulated result.
+   * @example
+   * ```ts
+   * type T0 = Call<T.ReduceRight<N.Add,0>,[1,2,3]>; // 6
+   * type T1 = Call<T.ReduceRight<N.Add,0>,[]>; // 0
+   * ```
+   */
   export interface ReduceRight<fn extends Fn, init> extends Fn {
     output: ReduceRightImpl<this["args"][0], init, fn>;
   }
@@ -74,6 +153,17 @@ export namespace Tuples {
       : never;
   }
 
+  /**
+   * Apply a predicate function to each element of a tuple and return a new tuple with the elements that satisfy the predicate.
+   * @params args[0] - A tuple of elements to be filtered.
+   * @param fn - A predicate function that takes an element of the tuple and returns a boolean.
+   * @returns A tuple with the elements that satisfy the predicate.
+   * @example
+   * ```ts
+   * type T0 = Call<T.Filter<B.Extends<string>>,[1,2,"3"]>; // ["3"]
+   * type T1 = Call<T.Filter<B.Extends<string>>,[]>; // []
+   * ```
+   */
   export interface Filter<fn extends Fn> extends Fn {
     output: ReduceImpl<this["args"][0], [], FilterFn<fn>>;
   }
@@ -87,10 +177,31 @@ export namespace Tuples {
       : FindImpl<rest, fn, [...index, any]>
     : never;
 
+  /**
+   * Apply a predicate function to each element of a tuple and return the first element that satisfies the predicate.
+   * @params args[0] - A tuple of elements to be filtered.
+   * @param fn - A predicate function that takes an element of the tuple and returns a boolean.
+   * @returns The first element that satisfies the predicate.
+   * @example
+   * ```ts
+   * type T0 = Call<T.Find<B.Extends<string>>,[1,2,"3",4,"5"]>; // "3"
+   * type T1 = Call<T.Find<B.Extends<string>>,[1,2]>; // never
+   * ```
+   */
   export interface Find<fn extends Fn> extends Fn {
     output: FindImpl<this["args"][0], fn>;
   }
 
+  /**
+   * Sum the elements of a tuple of numbers.
+   * @params args[0] - A tuple of numbers.
+   * @returns The sum of the elements of the tuple.
+   * @example
+   * ```ts
+   * type T0 = Call<T.Sum,[1,2,3]>; // 6
+   * type T1 = Call<T.Sum,[]>; // 0
+   * ```
+   */
   export interface Sum extends Fn {
     output: ReduceImpl<this["args"][0], 0, N.Add>;
   }
@@ -108,6 +219,18 @@ export namespace Tuples {
     ? DropImpl<tail, Iterator.Prev<n>>
     : [];
 
+  /**
+   * Drop the first n elements of a tuple.
+   * @params args[0] - A tuple of elements.
+   * @params n - The number of elements to drop.
+   * @returns A tuple with the first n elements dropped.
+   * @example
+   * ```ts
+   * type T0 = Call<T.Drop<2>,[1,2,3,4]>; // [3,4]
+   * type T1 = Call<T.Drop<2>,[1,2]>; // []
+   * type T2 = Call<T.Drop<2>,[]>; // []
+   * ```
+   */
   export interface Drop<n extends number> extends Fn {
     output: DropImpl<
       Extract<this["args"][0], readonly any[]>,
@@ -125,6 +248,18 @@ export namespace Tuples {
     ? TakeImpl<tail, Iterator.Prev<it>, [...output, head]>
     : output;
 
+  /**
+   * Take the first n elements of a tuple.
+   * @params args[0] - A tuple of elements.
+   * @params n - The number of elements to take.
+   * @returns A tuple with the first n elements.
+   * @example
+   * ```ts
+   * type T0 = Call<T.Take<2>,[1,2,3,4]>; // [1,2]
+   * type T1 = Call<T.Take<2>,[1,2]>; // [1,2]
+   * type T2 = Call<T.Take<2>,[]>; // []
+   * ```
+   */
   export interface Take<n extends number> extends Fn {
     output: TakeImpl<
       Extract<this["args"][0], readonly any[]>,
@@ -143,48 +278,92 @@ export namespace Tuples {
       : output
     : output;
 
+  /**
+   * Take the first elements of a tuple that satisfy a predicate function.
+   * @params args[0] - A tuple of elements.
+   * @param fn - A predicate function that takes an element of the tuple and returns a boolean.
+   * @returns A tuple with the first elements that satisfy the predicate.
+   * @example
+   * ```ts
+   * type T0 = Call<T.TakeWhile<B.Extends<number>>,[1,2,"3",4,"5"]>; // [1,2]
+   * type T1 = Call<T.TakeWhile<B.Extends<number>>,["1", 2]>; // []
+   * ```
+   */
   export interface TakeWhile<fn extends Fn> extends Fn {
     output: TakeWhileImpl<Extract<this["args"][0], readonly any[]>, fn>;
   }
 
+  /**
+   * Check if a tuple staisfies a predicate function for at least one element.
+   * @params args[0] - A tuple of elements.
+   * @param fn - A predicate function that takes an element of the tuple and returns a boolean.
+   * @returns A boolean indicating whether the predicate is satisfied by at least one element.
+   * @example
+   * ```ts
+   * type T0 = Call<T.Some<B.Extends<number>>,[1,2,"3",4,"5"]>; // true
+   * type T1 = Call<T.Some<B.Extends<number>>,["1", "2"]>; // false
+   * ```
+   */
   export interface Some<fn extends Fn> extends Fn {
     output: true extends Call<Tuples.Map<fn>, this["args"][0]>[number]
       ? true
       : false;
   }
 
+  /**
+   * Check if a tuple staisfies a predicate function for all elements.
+   * @params args[0] - A tuple of elements.
+   * @param fn - A predicate function that takes an element of the tuple and returns a boolean.
+   * @returns A boolean indicating whether the predicate is satisfied by all elements.
+   * @example
+   * ```ts
+   * type T0 = Call<T.Every<B.Extends<number>>,[1,2,"3",4,"5"]>; // false
+   * type T1 = Call<T.Every<B.Extends<number>>,["1", "2"]>; // false
+   * type T2 = Call<T.Every<B.Extends<number>>,[1, 2]>; // true
+   * ```
+   */
   export interface Every<fn extends Fn> extends Fn {
     output: false extends Call<Tuples.Map<fn>, this["args"][0]>[number]
       ? false
       : true;
   }
 
-  type SortImpl<xs extends any[], LessThanOrEqual extends Fn> = xs extends [
+  type SortImpl<xs extends any[], predicateFn extends Fn> = xs extends [
     infer head,
     ...infer tail
   ]
     ? [
         ...SortImpl<
-          Call<Tuples.Filter<F.Bind<LessThanOrEqual, [Args._, head]>>, tail>,
-          LessThanOrEqual
+          Call<Tuples.Filter<F.Bind<predicateFn, [Args._, head]>>, tail>,
+          predicateFn
         >,
         head,
         ...SortImpl<
           Call<
             Tuples.Filter<
-              F.Compose<[B.Not, F.Bind<LessThanOrEqual, [Args._, head]>]>
+              F.Compose<[B.Not, F.Bind<predicateFn, [Args._, head]>]>
             >,
             tail
           >,
-          LessThanOrEqual
+          predicateFn
         >
       ]
     : [];
 
-  export interface Sort<LessThanOrEqual extends Fn = N.LessThanOrEqual>
-    extends Fn {
+  /**
+   * Sort a tuple.
+   * @param args[0] - The tuple to sort.
+   * @param predicateFn - The predicate function to use for sorting. should compare 2 items and return a boolean.
+   * @returns The sorted tuple.
+   * @example
+   * ```ts
+   * type T0 = Call<Tuples.Sort,[3,2,1]>; // [1,2,3]
+   * type T1 = Call<Tuples.Sort<Strings.LessThan>,["b","c","a"]>; // ["a","b","c"]
+   * ```
+   */
+  export interface Sort<predicateFn extends Fn = N.LessThanOrEqual> extends Fn {
     output: this["args"] extends [infer xs extends any[]]
-      ? SortImpl<xs, LessThanOrEqual>
+      ? SortImpl<xs, predicateFn>
       : never;
   }
 

--- a/src/internals/tuples/Tuples.ts
+++ b/src/internals/tuples/Tuples.ts
@@ -334,14 +334,17 @@ export namespace Tuples {
   ]
     ? [
         ...SortImpl<
-          Call<Tuples.Filter<F.Bind<predicateFn, [Args._, head]>>, tail>,
+          Call<
+            Tuples.Filter<F.PartialApply<predicateFn, [Args._, head]>>,
+            tail
+          >,
           predicateFn
         >,
         head,
         ...SortImpl<
           Call<
             Tuples.Filter<
-              F.Compose<[B.Not, F.Bind<predicateFn, [Args._, head]>]>
+              F.Compose<[B.Not, F.PartialApply<predicateFn, [Args._, head]>]>
             >,
             tail
           >,

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -82,10 +82,10 @@ describe("Composition", () => {
     type tes1 = Expect<Equal<res1, 95>>;
   });
 
-  it("ApplyPartial", () => {
+  it("Bind", () => {
     type res1 = Call2<
       //   ^?
-      F.ApplyPartial<O.Assign, [Args._, Args._, { c: boolean }]>,
+      F.Bind<O.Assign, [Args._, Args._, { c: boolean }]>,
       { a: string },
       { b: number }
     >;
@@ -94,7 +94,7 @@ describe("Composition", () => {
 
     type res2 = Call<
       //   ^?
-      F.ApplyPartial<N.Add, [2]>,
+      F.Bind<N.Add, [2]>,
       2
     >;
     type test2 = Expect<Equal<res2, 4>>;
@@ -110,10 +110,10 @@ describe("Composition", () => {
       //   ^?
       {},
       [
-        F.ApplyPartial<O.Assign, [{ a: string }]>,
-        F.ApplyPartial<O.Assign, [{ b: number }]>,
-        F.ApplyPartial<O.Assign, [{ c: boolean }]>,
-        F.ApplyPartial<O.Assign, [{ d: bigint }]>
+        F.Bind<O.Assign, [{ a: string }]>,
+        F.Bind<O.Assign, [{ b: number }]>,
+        F.Bind<O.Assign, [{ c: boolean }]>,
+        F.Bind<O.Assign, [{ d: bigint }]>
       ]
     >;
     type test4 = Expect<

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -82,10 +82,10 @@ describe("Composition", () => {
     type tes1 = Expect<Equal<res1, 95>>;
   });
 
-  it("Bind", () => {
+  it("PartialApply", () => {
     type res1 = Call2<
       //   ^?
-      F.Bind<O.Assign, [Args._, Args._, { c: boolean }]>,
+      F.PartialApply<O.Assign, [Args._, Args._, { c: boolean }]>,
       { a: string },
       { b: number }
     >;
@@ -94,7 +94,7 @@ describe("Composition", () => {
 
     type res2 = Call<
       //   ^?
-      F.Bind<N.Add, [2]>,
+      F.PartialApply<N.Add, [2]>,
       2
     >;
     type test2 = Expect<Equal<res2, 4>>;
@@ -110,10 +110,10 @@ describe("Composition", () => {
       //   ^?
       {},
       [
-        F.Bind<O.Assign, [{ a: string }]>,
-        F.Bind<O.Assign, [{ b: number }]>,
-        F.Bind<O.Assign, [{ c: boolean }]>,
-        F.Bind<O.Assign, [{ d: bigint }]>
+        F.PartialApply<O.Assign, [{ a: string }]>,
+        F.PartialApply<O.Assign, [{ b: number }]>,
+        F.PartialApply<O.Assign, [{ c: boolean }]>,
+        F.PartialApply<O.Assign, [{ d: bigint }]>
       ]
     >;
     type test4 = Expect<

--- a/test/tuples.test.ts
+++ b/test/tuples.test.ts
@@ -3,6 +3,7 @@ import { Booleans } from "../src/internals/booleans/Booleans";
 import { Call, Fn, Pipe } from "../src/internals/core/Core";
 import { Equal, Expect } from "../src/internals/helpers";
 import { Numbers } from "../src/internals/numbers/Numbers";
+import { Strings } from "../src/internals/strings/Strings";
 import { Tuples } from "../src/internals/tuples/Tuples";
 
 describe("Tuples", () => {
@@ -174,13 +175,31 @@ describe("Tuples", () => {
     type tes2 = Expect<Equal<res2, true>>;
   });
 
-  it("Sort", () => {
+  it("Sort Numbers (default)", () => {
     type res1 = Call<
       //   ^?
       Tuples.Sort,
-      [1, 3, 2, 6, 5, 4]
+      [7, 1, 3, 2, 6, 5, 8, 4]
     >;
-    type tes1 = Expect<Equal<res1, [1, 2, 3, 4, 5, 6]>>;
+    type tes1 = Expect<Equal<res1, [1, 2, 3, 4, 5, 6, 7, 8]>>;
+  });
+
+  it("Sort Numbers (custom)", () => {
+    type res1 = Call<
+      //   ^?
+      Tuples.Sort<Numbers.LessThanOrEqual>,
+      [7, 1, 3, 2, 6, 5, 8, 4]
+    >;
+    type tes1 = Expect<Equal<res1, [1, 2, 3, 4, 5, 6, 7, 8]>>;
+  });
+
+  it("Sort Strings (custom)", () => {
+    type res1 = Call<
+      //   ^?
+      Tuples.Sort<Strings.LessThanOrEqual>,
+      ["c", "a", "f", "b", "e", "d"]
+    >;
+    type tes1 = Expect<Equal<res1, ["a", "b", "c", "d", "e", "f"]>>;
   });
 
   it("Join", () => {

--- a/test/tuples.test.ts
+++ b/test/tuples.test.ts
@@ -187,10 +187,10 @@ describe("Tuples", () => {
   it("Sort Numbers (custom)", () => {
     type res1 = Call<
       //   ^?
-      Tuples.Sort<Numbers.LessThanOrEqual>,
+      Tuples.Sort<Numbers.GreaterThanOrEqual>,
       [7, 1, 3, 2, 6, 5, 8, 4]
     >;
-    type tes1 = Expect<Equal<res1, [1, 2, 3, 4, 5, 6, 7, 8]>>;
+    type tes1 = Expect<Equal<res1, [8, 7, 6, 5, 4, 3, 2, 1]>>;
   });
 
   it("Sort Strings (custom)", () => {


### PR DESCRIPTION
- make sort generic (take a function that compares for less than equal values)
- add test for tuple string sort
- rename `ApplyPartial` into `PartialApply` which is the usual name for this
- fixed a bug on tail implementation returning never instead of an empty array
- add more documentation to tuples