### PR TITLE
fix(equality): improve equality for numbers and strings

### DIFF
--- a/src/internals/numbers/impl/compare.ts
+++ b/src/internals/numbers/impl/compare.ts
@@ -6,6 +6,7 @@ import type {
   Sign,
   Num,
 } from "./utils";
+import { Equal as _Equal } from "../../helpers";
 
 export type CompareLength<
   T extends any[],
@@ -70,7 +71,7 @@ export type CompareDigitNumbers<
 export type Compare<
   T extends number | bigint,
   U extends number | bigint
-> = T extends U
+> = _Equal<T, U> extends true
   ? 0
   : CompareDigitNumbers<ToDigitNumber<ToString<T>>, ToDigitNumber<ToString<U>>>;
 
@@ -87,12 +88,12 @@ export type GreaterThan<
 export type Equal<
   T extends number | bigint,
   U extends number | bigint
-> = Compare<T, U> extends 0 ? true : false;
+> = _Equal<T, U>;
 
 export type NotEqual<
   T extends number | bigint,
   U extends number | bigint
-> = Compare<T, U> extends 0 ? false : true;
+> = _Equal<T, U> extends true ? false : true;
 
 export type LessThanOrEqual<
   T extends number | bigint,

--- a/src/internals/strings/impl/compare.ts
+++ b/src/internals/strings/impl/compare.ts
@@ -1,6 +1,7 @@
-import { Call, Call2 } from "../../core/Core";
+import { Call2 } from "../../core/Core";
 import { Numbers } from "../../numbers/Numbers";
 import { StringToTuple } from "./split";
+import { Equal as _Equal } from "../../helpers";
 
 // prettier-ignore
 type ascii = {
@@ -53,10 +54,12 @@ type CharactersCompare<T extends string[], U extends string[]> = T extends [
   ? -1
   : 0;
 
-export type Compare<T extends string, U extends string> = CharactersCompare<
-  StringToTuple<T>,
-  StringToTuple<U>
->;
+export type Compare<T extends string, U extends string> = _Equal<
+  T,
+  U
+> extends true
+  ? 0
+  : CharactersCompare<StringToTuple<T>, StringToTuple<U>>;
 
 export type LessThan<T extends string, U extends string> = Compare<
   T,
@@ -72,14 +75,12 @@ export type LessThanOrEqual<T extends string, U extends string> = Compare<
   ? false
   : true;
 
-export type Equal<T extends string, U extends string> = Compare<T, U> extends 0
-  ? true
-  : false;
+export type Equal<T extends string, U extends string> = _Equal<T, U>;
 
-export type NotEqual<T extends string, U extends string> = Compare<
+export type NotEqual<T extends string, U extends string> = _Equal<
   T,
   U
-> extends 0
+> extends true
   ? false
   : true;
 


### PR DESCRIPTION
Little fix for equality. 
using strict equality for:
- numbers
- strings

Else there would have been some edge cases with unions, etc.
SHould also improve perfs for strings
