### PR TITLE
core: rename Args._ into _

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   Fn,
   Pipe,
   PipeRight,
+  _,
 } from "./internals/core/Core";
 import { Functions } from "./internals/functions/Functions";
 import { Numbers } from "./internals/numbers/Numbers";
@@ -14,9 +15,9 @@ import { Strings } from "./internals/strings/Strings";
 import { Tuples } from "./internals/tuples/Tuples";
 import { Unions } from "./internals/unions/Unions";
 import { Booleans } from "./internals/booleans/Booleans";
-import { Args } from "./internals/args/Args";
 
 export {
+  _,
   Fn,
   Pipe,
   PipeRight,
@@ -31,7 +32,6 @@ export {
   Numbers,
   Tuples,
   Functions,
-  Args,
   Booleans as B,
   Objects as O,
   Unions as U,

--- a/src/internals/args/Args.ts
+++ b/src/internals/args/Args.ts
@@ -1,3 +1,0 @@
-export namespace Args {
-  export type _ = "@hotscript/placeholder";
-}

--- a/src/internals/core/Core.ts
+++ b/src/internals/core/Core.ts
@@ -39,6 +39,8 @@ export namespace Fn {
 
 export type unset = "@hotscript/unset";
 
+export type _ = "@hotscript/placeholder";
+
 export type Apply<fn extends Fn, args extends unknown[]> = (fn & {
   args: args;
 })["return"];

--- a/src/internals/functions/impl/MergeArgs.ts
+++ b/src/internals/functions/impl/MergeArgs.ts
@@ -1,12 +1,11 @@
-import { Args } from "../../args/Args";
-import { unset } from "../../core/Core";
+import { unset, _ } from "../../core/Core";
 import { IsNever, RemoveUnknownArrayConstraint } from "../../helpers";
 
 type ExcludePlaceholders<xs, output extends any[] = []> = xs extends [
   infer first,
   ...infer rest
 ]
-  ? first extends Args._
+  ? first extends _
     ? ExcludePlaceholders<rest, output>
     : ExcludePlaceholders<rest, [...output, first]>
   : output;
@@ -18,7 +17,7 @@ type MergeArgsRec<
 > = partialArgs extends [infer partialFirst, ...infer partialRest]
   ? [partialFirst] extends [never]
     ? MergeArgsRec<pipedArgs, partialRest, [...output, partialFirst]>
-    : [partialFirst] extends [Args._]
+    : [partialFirst] extends [_]
     ? pipedArgs extends [infer pipedFirst, ...infer pipedRest]
       ? MergeArgsRec<pipedRest, partialRest, [...output, pipedFirst]>
       : [...output, ...ExcludePlaceholders<partialRest>]
@@ -28,7 +27,7 @@ type MergeArgsRec<
 type EmptyIntoPlaceholder<x> = IsNever<x> extends true
   ? never
   : [x] extends [unset]
-  ? Args._
+  ? _
   : x;
 
 type MapEmptyIntoPlaceholder<xs, output extends any[] = []> = xs extends [

--- a/src/internals/numbers/Numbers.ts
+++ b/src/internals/numbers/Numbers.ts
@@ -1,12 +1,11 @@
-import { Fn, unset } from "../core/Core";
-import { Args } from "../args/Args";
+import { Fn, unset, _ } from "../core/Core";
 import * as Impl from "./impl/numbers";
 import { Functions } from "../functions/Functions";
 
 export namespace Numbers {
   export type Add<
-    n1 extends number | bigint | Args._ | unset = unset,
-    n2 extends number | bigint | Args._ | unset = unset
+    n1 extends number | bigint | _ | unset = unset,
+    n2 extends number | bigint | _ | unset = unset
   > = Functions.PartialApply<AddFn, [n1, n2]>;
 
   interface AddFn extends Fn {
@@ -20,8 +19,8 @@ export namespace Numbers {
   }
 
   export type Sub<
-    n1 extends number | bigint | Args._ | unset = unset,
-    n2 extends number | bigint | Args._ | unset = unset
+    n1 extends number | bigint | _ | unset = unset,
+    n2 extends number | bigint | _ | unset = unset
   > = Functions.PartialApply<SubFn, n2 extends unset ? [unset, n1] : [n1, n2]>;
 
   interface SubFn extends Fn {
@@ -37,8 +36,8 @@ export namespace Numbers {
   // Multiply
 
   export type Mul<
-    n1 extends number | bigint | Args._ | unset = unset,
-    n2 extends number | bigint | Args._ | unset = unset
+    n1 extends number | bigint | _ | unset = unset,
+    n2 extends number | bigint | _ | unset = unset
   > = Functions.PartialApply<MulFn, [n1, n2]>;
 
   interface MulFn extends Fn {
@@ -54,8 +53,8 @@ export namespace Numbers {
   // Divide
 
   export type Div<
-    n1 extends number | bigint | Args._ | unset = unset,
-    n2 extends number | bigint | Args._ | unset = unset
+    n1 extends number | bigint | _ | unset = unset,
+    n2 extends number | bigint | _ | unset = unset
   > = Functions.PartialApply<DivFn, n2 extends unset ? [unset, n1] : [n1, n2]>;
 
   interface DivFn extends Fn {
@@ -71,8 +70,8 @@ export namespace Numbers {
   // Modulo
 
   export type Mod<
-    n1 extends number | bigint | Args._ | unset = unset,
-    n2 extends number | bigint | Args._ | unset = unset
+    n1 extends number | bigint | _ | unset = unset,
+    n2 extends number | bigint | _ | unset = unset
   > = Functions.PartialApply<ModFn, [n1, n2]>;
 
   interface ModFn extends Fn {
@@ -86,7 +85,7 @@ export namespace Numbers {
   }
 
   // Negate
-  export type Negate<n extends number | bigint | Args._ | unset = unset> =
+  export type Negate<n extends number | bigint | _ | unset = unset> =
     Functions.PartialApply<NegateFn, [n]>;
 
   interface NegateFn extends Fn {
@@ -96,7 +95,7 @@ export namespace Numbers {
   }
 
   // Absolute
-  export type Abs<n extends number | bigint | Args._ | unset = unset> =
+  export type Abs<n extends number | bigint | _ | unset = unset> =
     Functions.PartialApply<AbsFn, [n]>;
 
   export interface AbsFn extends Fn {
@@ -107,8 +106,8 @@ export namespace Numbers {
 
   // Power
   export type Power<
-    n1 extends number | bigint | Args._ | unset = unset,
-    n2 extends number | bigint | Args._ | unset = unset
+    n1 extends number | bigint | _ | unset = unset,
+    n2 extends number | bigint | _ | unset = unset
   > = Functions.PartialApply<
     PowerFn,
     n2 extends unset ? [unset, n1] : [n1, n2]
@@ -126,8 +125,8 @@ export namespace Numbers {
 
   // Compare
   export type Compare<
-    n1 extends number | bigint | Args._ | unset = unset,
-    n2 extends number | bigint | Args._ | unset = unset
+    n1 extends number | bigint | _ | unset = unset,
+    n2 extends number | bigint | _ | unset = unset
   > = Functions.PartialApply<
     CompareFn,
     n2 extends unset ? [unset, n1] : [n1, n2]
@@ -145,8 +144,8 @@ export namespace Numbers {
 
   // Equal
   export type Equal<
-    n1 extends number | bigint | Args._ | unset = unset,
-    n2 extends number | bigint | Args._ | unset = unset
+    n1 extends number | bigint | _ | unset = unset,
+    n2 extends number | bigint | _ | unset = unset
   > = Functions.PartialApply<
     EqualFn,
     n2 extends unset ? [unset, n1] : [n1, n2]
@@ -164,8 +163,8 @@ export namespace Numbers {
 
   // NotEqual
   export type NotEqual<
-    n1 extends number | bigint | Args._ | unset = unset,
-    n2 extends number | bigint | Args._ | unset = unset
+    n1 extends number | bigint | _ | unset = unset,
+    n2 extends number | bigint | _ | unset = unset
   > = Functions.PartialApply<
     NotEqualFn,
     n2 extends unset ? [unset, n1] : [n1, n2]
@@ -183,8 +182,8 @@ export namespace Numbers {
 
   // LessThan
   export type LessThan<
-    n1 extends number | bigint | Args._ | unset = unset,
-    n2 extends number | bigint | Args._ | unset = unset
+    n1 extends number | bigint | _ | unset = unset,
+    n2 extends number | bigint | _ | unset = unset
   > = Functions.PartialApply<
     LessThanFn,
     n2 extends unset ? [unset, n1] : [n1, n2]
@@ -202,8 +201,8 @@ export namespace Numbers {
 
   // LessThanOrEqual
   export type LessThanOrEqual<
-    n1 extends number | bigint | Args._ | unset = unset,
-    n2 extends number | bigint | Args._ | unset = unset
+    n1 extends number | bigint | _ | unset = unset,
+    n2 extends number | bigint | _ | unset = unset
   > = Functions.PartialApply<
     LessThanOrEqualFn,
     n2 extends unset ? [unset, n1] : [n1, n2]
@@ -221,8 +220,8 @@ export namespace Numbers {
 
   // GreaterThan
   export type GreaterThan<
-    n1 extends number | bigint | Args._ | unset = unset,
-    n2 extends number | bigint | Args._ | unset = unset
+    n1 extends number | bigint | _ | unset = unset,
+    n2 extends number | bigint | _ | unset = unset
   > = Functions.PartialApply<
     GreaterThanFn,
     n2 extends unset ? [unset, n1] : [n1, n2]
@@ -240,8 +239,8 @@ export namespace Numbers {
 
   // GreaterThanOrEqual
   export type GreaterThanOrEqual<
-    n1 extends number | bigint | Args._ | unset = unset,
-    n2 extends number | bigint | Args._ | unset = unset
+    n1 extends number | bigint | _ | unset = unset,
+    n2 extends number | bigint | _ | unset = unset
   > = Functions.PartialApply<
     GreaterThanOrEqualFn,
     n2 extends unset ? [unset, n1] : [n1, n2]

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -1,11 +1,10 @@
-import { Args } from "../args/Args";
 import {
   GetFromPath,
   IsArrayStrict,
   Prettify,
   UnionToIntersection,
 } from "../helpers";
-import { Call, Call2, Fn, unset } from "../core/Core";
+import { Call, Call2, Fn, unset, _ } from "../core/Core";
 import { Std } from "../std/Std";
 import { Strings } from "../strings/Strings";
 import { Functions } from "../functions/Functions";
@@ -184,7 +183,7 @@ export namespace Objects {
   }
 
   export type Get<
-    path extends string | number | Args._ | unset = unset,
+    path extends string | number | _ | unset = unset,
     obj = unset
   > = Functions.PartialApply<GetFn, [path, obj]>;
 

--- a/src/internals/strings/Strings.ts
+++ b/src/internals/strings/Strings.ts
@@ -1,7 +1,6 @@
-import { Fn, unset } from "../core/Core";
+import { Fn, unset, _ } from "../core/Core";
 import { Std } from "../std/Std";
 import { Tuples } from "../tuples/Tuples";
-import { Args } from "../args/Args";
 import * as H from "../helpers";
 import * as Impl from "./impl/strings";
 import { Functions } from "../functions/Functions";
@@ -42,7 +41,7 @@ export namespace Strings {
    * ```
    */
   export type TrimLeft<
-    Sep extends string | Args._ = " ",
+    Sep extends string | _ = " ",
     Str = unset
   > = Functions.PartialApply<TrimLeftFn, [Sep, Str]>;
 
@@ -67,7 +66,7 @@ export namespace Strings {
    * ```
    */
   export type TrimRight<
-    Sep extends string | Args._ = " ",
+    Sep extends string | _ = " ",
     Str = unset
   > = Functions.PartialApply<TrimRightFn, [Sep, Str]>;
 
@@ -92,7 +91,7 @@ export namespace Strings {
    * ```
    */
   export type Trim<
-    Sep extends string | Args._ = " ",
+    Sep extends string | _ = " ",
     Str = unset
   > = Functions.PartialApply<TrimFn, [Sep, Str]>;
 
@@ -117,8 +116,8 @@ export namespace Strings {
    * type T0 = Call<Strings.Replace<".","/">,"a.b.c.d">; // "a/b/c/d"
    */
   export type Replace<
-    from extends string | unset | Args._ = unset,
-    to extends string | unset | Args._ = unset,
+    from extends string | unset | _ = unset,
+    to extends string | unset | _ = unset,
     str = unset
   > = Functions.PartialApply<ReplaceFn, [from, to, str]>;
 
@@ -144,8 +143,8 @@ export namespace Strings {
    * type T0 = Call<Strings.Slice<1,9>,"1234567890">; // "23456789"
    */
   export type Slice<
-    start extends number | unset | Args._ = unset,
-    end extends number | unset | Args._ = unset
+    start extends number | unset | _ = unset,
+    end extends number | unset | _ = unset
   > = Functions.ComposeLeft<
     [Strings.Split<"">, Tuples.Take<end>, Tuples.Drop<start>, Tuples.Join<"">]
   >;
@@ -162,8 +161,8 @@ export namespace Strings {
    * ```
    */
   export type Split<
-    Sep extends string | unset | Args._ = unset,
-    Str extends string | unset | Args._ = unset
+    Sep extends string | unset | _ = unset,
+    Str extends string | unset | _ = unset
   > = Functions.PartialApply<SplitFn, [Sep, Str]>;
 
   export interface SplitFn extends Fn {
@@ -183,8 +182,8 @@ export namespace Strings {
    * ```
    */
   export type Repeat<
-    Times extends number | Args._ | unset = unset,
-    Str extends number | Args._ | unset = unset
+    Times extends number | _ | unset = unset,
+    Str extends number | _ | unset = unset
   > = Functions.PartialApply<RepeatFn, [Times, Str]>;
 
   interface RepeatFn extends Fn {
@@ -208,8 +207,8 @@ export namespace Strings {
    * ```
    */
   export type StartsWith<
-    Start extends string | Args._ | unset = unset,
-    Str extends string | Args._ | unset = unset
+    Start extends string | _ | unset = unset,
+    Str extends string | _ | unset = unset
   > = Functions.PartialApply<StartsWithFn, [Start, Str]>;
 
   interface StartsWithFn extends Fn {
@@ -232,8 +231,8 @@ export namespace Strings {
    * ```
    */
   export type EndsWith<
-    End extends string | Args._ | unset = unset,
-    Str extends string | Args._ | unset = unset
+    End extends string | _ | unset = unset,
+    Str extends string | _ | unset = unset
   > = Functions.PartialApply<EndsWithFn, [End, Str]>;
 
   interface EndsWithFn extends Fn {
@@ -300,8 +299,8 @@ export namespace Strings {
    * ```
    */
   export type Prepend<
-    Start extends string | Args._ | unset = unset,
-    Str extends string | Args._ | unset = unset
+    Start extends string | _ | unset = unset,
+    Str extends string | _ | unset = unset
   > = Functions.PartialApply<PrependFn, [Start, Str]>;
 
   interface PrependFn extends Fn {
@@ -322,8 +321,8 @@ export namespace Strings {
    * ```
    */
   export type Append<
-    End extends string | Args._ | unset = unset,
-    Str extends string | Args._ | unset = unset
+    End extends string | _ | unset = unset,
+    Str extends string | _ | unset = unset
   > = Functions.PartialApply<AppendFn, [End, Str]>;
 
   interface AppendFn extends Fn {
@@ -430,8 +429,8 @@ export namespace Strings {
    * Compare two strings. (only works with ascii extended characters)
    * @param args[0] - The first string to compare.
    * @param args[1] - The second string to compare.
-   * @n1 - The first string to compare or Args._.
-   * @n2 - The second string to compare or Args._.
+   * @n1 - The first string to compare or _.
+   * @n2 - The second string to compare or _.
    * @returns The result of the comparison.
    * @example
    * ```ts
@@ -441,8 +440,8 @@ export namespace Strings {
    * ```
    */
   export type Compare<
-    n1 extends string | Args._ | unset = unset,
-    n2 extends string | Args._ | unset = unset
+    n1 extends string | _ | unset = unset,
+    n2 extends string | _ | unset = unset
   > = Functions.PartialApply<
     CompareFn,
     n2 extends unset ? [unset, n1] : [n1, n2]
@@ -462,8 +461,8 @@ export namespace Strings {
    * Check if a string is lexically less than another string. (only works with ascii extended characters)
    * @param args[0] - The first string to compare.
    * @param args[1] - The second string to compare.
-   * @n1 - The first string to compare or Args._.
-   * @n2 - The second string to compare or Args._.
+   * @n1 - The first string to compare or _.
+   * @n2 - The second string to compare or _.
    * @returns True if the first string is lexically less than the second string, false otherwise.
    * @example
    * ```ts
@@ -473,8 +472,8 @@ export namespace Strings {
    * ```
    */
   export type LessThan<
-    n1 extends string | Args._ | unset = unset,
-    n2 extends string | Args._ | unset = unset
+    n1 extends string | _ | unset = unset,
+    n2 extends string | _ | unset = unset
   > = Functions.PartialApply<
     LessThanFn,
     n2 extends unset ? [unset, n1] : [n1, n2]
@@ -494,8 +493,8 @@ export namespace Strings {
    * Check if a string is lexically less than or equal to another string. (only works with ascii extended characters)
    * @param args[0] - The first string to compare.
    * @param args[1] - The second string to compare.
-   * @n1 - The first string to compare or Args._.
-   * @n2 - The second string to compare or Args._.
+   * @n1 - The first string to compare or _.
+   * @n2 - The second string to compare or _.
    * @returns True if the first string is lexically less than or equal to the second string, false otherwise.
    * @example
    * ```ts
@@ -504,8 +503,8 @@ export namespace Strings {
    * type T2 = Call2<Strings.LessThanOrEqual,"abc","abc">; // true
    */
   export type LessThanOrEqual<
-    n1 extends string | Args._ | unset = unset,
-    n2 extends string | Args._ | unset = unset
+    n1 extends string | _ | unset = unset,
+    n2 extends string | _ | unset = unset
   > = Functions.PartialApply<
     LessThanOrEqualFn,
     n2 extends unset ? [unset, n1] : [n1, n2]
@@ -525,8 +524,8 @@ export namespace Strings {
    * Check if a string is lexically greater than another string. (only works with ascii extended characters)
    * @param args[0] - The first string to compare.
    * @param args[1] - The second string to compare.
-   * @n1 - The first string to compare or Args._.
-   * @n2 - The second string to compare or Args._.
+   * @n1 - The first string to compare or _.
+   * @n2 - The second string to compare or _.
    * @returns True if the first string is lexically greater than the second string, false otherwise.
    * @example
    * ```ts
@@ -536,8 +535,8 @@ export namespace Strings {
    * ```
    */
   export type GreaterThan<
-    n1 extends string | Args._ | unset = unset,
-    n2 extends string | Args._ | unset = unset
+    n1 extends string | _ | unset = unset,
+    n2 extends string | _ | unset = unset
   > = Functions.PartialApply<
     GreaterThanFn,
     n2 extends unset ? [unset, n1] : [n1, n2]
@@ -557,8 +556,8 @@ export namespace Strings {
    * Check if a string is lexically greater than or equal to another string. (only works with ascii extended characters)
    * @param args[0] - The first string to compare.
    * @param args[1] - The second string to compare.
-   * @n1 - The first string to compare or Args._.
-   * @n2 - The second string to compare or Args._.
+   * @n1 - The first string to compare or _.
+   * @n2 - The second string to compare or _.
    * @returns True if the first string is lexically greater than or equal to the second string, false otherwise.
    * @example
    * ```ts
@@ -568,8 +567,8 @@ export namespace Strings {
    * ```
    */
   export type GreaterThanOrEqual<
-    n1 extends string | Args._ | unset = unset,
-    n2 extends string | Args._ | unset = unset
+    n1 extends string | _ | unset = unset,
+    n2 extends string | _ | unset = unset
   > = Functions.PartialApply<
     GreaterThanOrEqualFn,
     n2 extends unset ? [unset, n1] : [n1, n2]

--- a/src/internals/tuples/Tuples.ts
+++ b/src/internals/tuples/Tuples.ts
@@ -1,8 +1,7 @@
-import { Args } from "../args/Args";
 import { Booleans as B } from "../booleans/Booleans";
 import { Functions as F, Functions } from "../functions/Functions";
 import { Numbers as N } from "../numbers/Numbers";
-import { Call, Call2, Fn, unset } from "../core/Core";
+import { Call, Call2, Fn, unset, _ } from "../core/Core";
 import { Iterator, Stringifiable } from "../helpers";
 
 export namespace Tuples {
@@ -228,7 +227,7 @@ export namespace Tuples {
    * ```
    */
   export type Drop<
-    n extends number | unset | Args._ = unset,
+    n extends number | unset | _ = unset,
     str = unset
   > = Functions.PartialApply<DropFn, [n, str]>;
 
@@ -264,7 +263,7 @@ export namespace Tuples {
    * ```
    */
   export type Take<
-    n extends number | unset | Args._ = unset,
+    n extends number | unset | _ = unset,
     str = unset
   > = Functions.PartialApply<TakeFn, [n, str]>;
 
@@ -344,17 +343,14 @@ export namespace Tuples {
   ]
     ? [
         ...SortImpl<
-          Call<
-            Tuples.Filter<F.PartialApply<predicateFn, [Args._, head]>>,
-            tail
-          >,
+          Call<Tuples.Filter<F.PartialApply<predicateFn, [_, head]>>, tail>,
           predicateFn
         >,
         head,
         ...SortImpl<
           Call<
             Tuples.Filter<
-              F.Compose<[B.Not, F.PartialApply<predicateFn, [Args._, head]>]>
+              F.Compose<[B.Not, F.PartialApply<predicateFn, [_, head]>]>
             >,
             tail
           >,
@@ -400,7 +396,7 @@ export namespace Tuples {
    * ```
    */
   export type Join<
-    Sep extends string | Args._ | unset = unset,
+    Sep extends string | _ | unset = unset,
     Tuple = unset
   > = Functions.PartialApply<JoinFn, [Sep, Tuple]>;
 
@@ -498,7 +494,7 @@ export namespace Tuples {
    * ```
    */
   export type At<
-    index extends number | Args._ | unset = unset,
+    index extends number | _ | unset = unset,
     tuple = unset
   > = Functions.PartialApply<AtFn, [index, tuple]>;
 

--- a/test/booleans.test.ts
+++ b/test/booleans.test.ts
@@ -1,4 +1,4 @@
-import { Call, Eval, Tuples, Booleans, T, Args } from "../src/index";
+import { Call, Eval, Tuples, Booleans, T, _ } from "../src/index";
 import { Equal, Expect } from "../src/internals/helpers";
 
 describe("Booleans", () => {
@@ -95,10 +95,10 @@ describe("Booleans", () => {
       type res4 = Eval<Booleans.Extends<1, number>>;
       type test4 = Expect<Equal<res4, true>>;
 
-      type res5 = Call<Booleans.Extends<Args._, 2>, 1>;
+      type res5 = Call<Booleans.Extends<_, 2>, 1>;
       type test5 = Expect<Equal<res5, false>>;
 
-      type res6 = Call<T.Map<Booleans.Extends<Args._, number>>, [1, "2", 3]>;
+      type res6 = Call<T.Map<Booleans.Extends<_, number>>, [1, "2", 3]>;
       type test6 = Expect<Equal<res6, [true, false, true]>>;
 
       type res7 = Call<Booleans.Extends<number>, 1>;

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -9,7 +9,7 @@ import {
   O,
   N,
   F,
-  Args,
+  _,
 } from "../src/index";
 import { unset } from "../src/internals/core/Core";
 import { MergeArgs } from "../src/internals/functions/impl/MergeArgs";
@@ -60,7 +60,7 @@ describe("Composition", () => {
         Strings.Split<".">,
         Tuples.Map<Strings.ToNumber>,
         Tuples.Map<Numbers.Add<10>>,
-        Tuples.Map<Numbers.Sub<Args._, 1>>,
+        Tuples.Map<Numbers.Sub<_, 1>>,
         Tuples.Sum
       ]
     >;

--- a/test/numbers.test.ts
+++ b/test/numbers.test.ts
@@ -1,4 +1,4 @@
-import { Call, Call2, Eval, Numbers, Tuples, Args, T } from "../src/index";
+import { Call, Call2, Eval, Numbers, Tuples, _, T } from "../src/index";
 import { Equal, Expect } from "../src/internals/helpers";
 
 describe("Numbers", () => {
@@ -37,7 +37,7 @@ describe("Numbers", () => {
     });
 
     it("can be called with one pre-filled argument", () => {
-      type res1 = Call<Tuples.Map<Numbers.Sub<Args._, 1>>, [1, 2, 3]>;
+      type res1 = Call<Tuples.Map<Numbers.Sub<_, 1>>, [1, 2, 3]>;
       //    ^?
       type test1 = Expect<Equal<res1, [0, 1, 2]>>;
     });
@@ -54,7 +54,7 @@ describe("Numbers", () => {
     });
 
     it("shouldn't reverse if the position is explicit", () => {
-      type res1 = Call<Numbers.Sub<1, Args._>, 2>;
+      type res1 = Call<Numbers.Sub<1, _>, 2>;
       //    ^?
       type test1 = Expect<Equal<res1, -1>>;
     });
@@ -76,7 +76,7 @@ describe("Numbers", () => {
     });
 
     it("can be called with one pre-filled argument", () => {
-      type res1 = Call<Tuples.Map<Numbers.Mul<Args._, 2>>, [1, 2, 3]>;
+      type res1 = Call<Tuples.Map<Numbers.Mul<_, 2>>, [1, 2, 3]>;
       //    ^?
       type test1 = Expect<Equal<res1, [2, 4, 6]>>;
     });
@@ -100,7 +100,7 @@ describe("Numbers", () => {
     });
 
     it("can be called with one pre-filled argument", () => {
-      type res1 = Call<Tuples.Map<Numbers.Div<Args._, 2>>, [2, 4, 6]>;
+      type res1 = Call<Tuples.Map<Numbers.Div<_, 2>>, [2, 4, 6]>;
       //    ^?
       type test1 = Expect<Equal<res1, [1, 2, 3]>>;
     });
@@ -120,7 +120,7 @@ describe("Numbers", () => {
     });
 
     it("can be called with one pre-filled argument", () => {
-      type res1 = Call<Tuples.Map<Numbers.Mod<Args._, 5>>, [2, 4, 6]>;
+      type res1 = Call<Tuples.Map<Numbers.Mod<_, 5>>, [2, 4, 6]>;
       //    ^?
       type test1 = Expect<Equal<res1, [2, 4, 1]>>;
     });
@@ -176,7 +176,7 @@ describe("Numbers", () => {
     });
 
     it("can be called with one pre-filled arguments", () => {
-      type res1 = Call<Tuples.Map<Numbers.Power<Args._, 2>>, [1, 2, 3]>;
+      type res1 = Call<Tuples.Map<Numbers.Power<_, 2>>, [1, 2, 3]>;
       //    ^?
       type test1 = Expect<Equal<res1, [1, 4, 9]>>;
     });
@@ -204,7 +204,7 @@ describe("Numbers", () => {
     });
 
     it("can be called with one pre-filled arguments", () => {
-      type res1 = Call<Tuples.Map<Numbers.Compare<Args._, 2>>, [1, 2, 3]>;
+      type res1 = Call<Tuples.Map<Numbers.Compare<_, 2>>, [1, 2, 3]>;
       //    ^?
       type test1 = Expect<Equal<res1, [-1, 0, 1]>>;
     });
@@ -232,12 +232,9 @@ describe("Numbers", () => {
     });
 
     it("can be called with one pre-filled arguments", () => {
-      type res1 = Call<Tuples.Map<Numbers.LessThan<Args._, 2>>, [1, 2, 3]>;
+      type res1 = Call<Tuples.Map<Numbers.LessThan<_, 2>>, [1, 2, 3]>;
       //    ^?
       type test1 = Expect<Equal<res1, [true, false, false]>>;
-      type res2 = Call<Tuples.Map<Numbers.LessThan<2>>, [1, 2, 3]>;
-      //    ^?
-      type test2 = Expect<Equal<res1, [true, false, false]>>;
     });
 
     it("can be called with 1 pre-filled arguments", () => {
@@ -263,10 +260,7 @@ describe("Numbers", () => {
     });
 
     it("can be called with one pre-filled arguments", () => {
-      type res1 = Call<
-        Tuples.Map<Numbers.LessThanOrEqual<Args._, 2>>,
-        [1, 2, 3]
-      >;
+      type res1 = Call<Tuples.Map<Numbers.LessThanOrEqual<_, 2>>, [1, 2, 3]>;
       //    ^?
       type test1 = Expect<Equal<res1, [true, true, false]>>;
     });
@@ -294,7 +288,7 @@ describe("Numbers", () => {
     });
 
     it("can be called with one pre-filled arguments", () => {
-      type res1 = Call<Tuples.Map<Numbers.GreaterThan<Args._, 2>>, [1, 2, 3]>;
+      type res1 = Call<Tuples.Map<Numbers.GreaterThan<_, 2>>, [1, 2, 3]>;
       //    ^?
       type test1 = Expect<Equal<res1, [false, false, true]>>;
     });
@@ -309,10 +303,10 @@ describe("Numbers", () => {
       type res4 = Eval<Numbers.GreaterThan<1, 2>>;
       type test4 = Expect<Equal<res4, false>>;
 
-      type res5 = Call<Numbers.GreaterThan<Args._, 2>, 1>;
+      type res5 = Call<Numbers.GreaterThan<_, 2>, 1>;
       type test5 = Expect<Equal<res5, false>>;
 
-      type res6 = Call<T.Map<Numbers.GreaterThan<Args._, 2>>, [1, 2, 3]>;
+      type res6 = Call<T.Map<Numbers.GreaterThan<_, 2>>, [1, 2, 3]>;
       type test6 = Expect<Equal<res6, [false, false, true]>>;
 
       type res7 = Call<Numbers.GreaterThan<2>, 1>;
@@ -339,10 +333,7 @@ describe("Numbers", () => {
     });
 
     it("can be called with one pre-filled arguments", () => {
-      type res1 = Call<
-        Tuples.Map<Numbers.GreaterThanOrEqual<Args._, 2>>,
-        [1, 2, 3]
-      >;
+      type res1 = Call<Tuples.Map<Numbers.GreaterThanOrEqual<_, 2>>, [1, 2, 3]>;
       //    ^?
       type test1 = Expect<Equal<res1, [false, true, true]>>;
     });

--- a/test/strings.test.ts
+++ b/test/strings.test.ts
@@ -1,4 +1,4 @@
-import { Args, Call, Call2, Strings } from "../src/index";
+import { _, Call, Call2, Strings } from "../src/index";
 import { Equal, Expect } from "../src/internals/helpers";
 
 describe("Strings", () => {
@@ -219,7 +219,7 @@ describe("Strings", () => {
     type res2 = Call<Strings.Compare<"a">, "b">;
     //    ^?
     type test2 = Expect<Equal<res2, 1>>;
-    type res3 = Call<Strings.Compare<"a", Args._>, "b">;
+    type res3 = Call<Strings.Compare<"a", _>, "b">;
     //    ^?
     type test3 = Expect<Equal<res3, -1>>;
     type res4 = Call<Strings.Compare<"b">, "a">;

--- a/test/tuples.test.ts
+++ b/test/tuples.test.ts
@@ -1,6 +1,5 @@
-import { Args } from "../src/internals/args/Args";
 import { Booleans } from "../src/internals/booleans/Booleans";
-import { Call, Eval, Fn, Pipe } from "../src/internals/core/Core";
+import { Call, Eval, Fn, Pipe, _ } from "../src/internals/core/Core";
 import { Equal, Expect } from "../src/internals/helpers";
 import { Numbers } from "../src/internals/numbers/Numbers";
 import { Strings } from "../src/internals/strings/Strings";
@@ -125,16 +124,14 @@ describe("Tuples", () => {
   it("TakeWhile", () => {
     type res1 = Call<
       //   ^?
-      Tuples.TakeWhile<Booleans.Extends<Args._, string>>,
+      Tuples.TakeWhile<Booleans.Extends<_, string>>,
       ["a", "b", "c", 2, "d"]
     >;
     type tes1 = Expect<Equal<res1, ["a", "b", "c"]>>;
 
-    type NewType = Args._;
-
     type res2 = Call<
       //   ^?
-      Tuples.TakeWhile<Booleans.Extends<NewType, number>>,
+      Tuples.TakeWhile<Booleans.Extends<_, number>>,
       [1, 2, "a", "b", "c", 2, "d"]
     >;
     type tes2 = Expect<Equal<res2, [1, 2]>>;
@@ -143,14 +140,14 @@ describe("Tuples", () => {
   it("Every", () => {
     type res1 = Call<
       //   ^?
-      Tuples.Every<Booleans.Extends<Args._, string>>,
+      Tuples.Every<Booleans.Extends<_, string>>,
       ["a", "b", "c", "d"]
     >;
     type tes1 = Expect<Equal<res1, true>>;
 
     type res2 = Call<
       //   ^?
-      Tuples.Every<Booleans.Extends<Args._, number>>,
+      Tuples.Every<Booleans.Extends<_, number>>,
       [1, 2, "a", "b", "c", 2, "d"]
     >;
     type tes2 = Expect<Equal<res2, false>>;
@@ -159,14 +156,14 @@ describe("Tuples", () => {
   it("Some", () => {
     type res1 = Call<
       //   ^?
-      Tuples.Some<Booleans.Extends<Args._, number>>,
+      Tuples.Some<Booleans.Extends<_, number>>,
       ["a", "b", "c", "d"]
     >;
     type tes1 = Expect<Equal<res1, false>>;
 
     type res2 = Call<
       //   ^?
-      Tuples.Some<Booleans.Extends<Args._, number>>,
+      Tuples.Some<Booleans.Extends<_, number>>,
       [1, 2, "a", "b", "c", 2, "d"]
     >;
     type tes2 = Expect<Equal<res2, true>>;


### PR DESCRIPTION
I figured we don't really need to worry about possible collisions with lodash since we are at the type level.

`_` Makes partial expressions look much cleaner IMO.

Before:

```ts
type T = Pipe<
//   ^? "left-hello-right"
    "hello",
    [
         Strings.Prepend<Args._, "-right">,
         Strings.Prepend<"left-", Args._>,
    ]
>
```

After

```ts
type T = Pipe<
//   ^? "left-hello-right"
    "hello",
    [
         Strings.Prepend<_, "-right">,
         Strings.Prepend<"left-", _>,
    ]
>
```