### PR TITLE
feat(core): revert access to args with Fn.args<this>

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ type res1 = Pipe<
 
 // This is a type-level "lambda"!
 interface Duplicate extends Fn {
-  return: [Fn.arg0<this>, Fn.arg0<this>];
+  return: [this["arg0"], this["arg0"]];
 }
 
 type result1 = Call<Tuples.Map<Duplicate>, [1, 2, 3, 4]>;

--- a/src/internals/booleans/Booleans.ts
+++ b/src/internals/booleans/Booleans.ts
@@ -7,7 +7,7 @@ export namespace Booleans {
   type ExtendsImpl<a, b> = [a] extends [b] ? true : false;
 
   interface ExtendsFn extends Fn {
-    return: Fn.args<this> extends [infer first, infer second, ...any]
+    return: this["args"] extends [infer first, infer second, ...any]
       ? ExtendsImpl<first, second>
       : never;
   }
@@ -20,15 +20,13 @@ export namespace Booleans {
   type NotImpl<a> = a extends true ? false : true;
 
   interface NotFn extends Fn {
-    return: Fn.args<this> extends [infer first, ...any]
-      ? NotImpl<first>
-      : never;
+    return: this["args"] extends [infer first, ...any] ? NotImpl<first> : never;
   }
 
   export type Not<a = unset> = Functions.PartialApply<NotFn, [a]>;
 
   interface EqualsFn extends Fn {
-    return: Fn.args<this> extends [infer a, infer b, ...any]
+    return: this["args"] extends [infer a, infer b, ...any]
       ? Equal<a, b>
       : never;
   }
@@ -47,7 +45,7 @@ export namespace Booleans {
   >;
 
   interface AndFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer first extends boolean,
       infer second extends boolean,
       ...any
@@ -59,7 +57,7 @@ export namespace Booleans {
   export type And<a = unset, b = unset> = Functions.PartialApply<AndFn, [a, b]>;
 
   interface OrFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer first extends boolean,
       infer second extends boolean,
       ...any

--- a/src/internals/core/Core.ts
+++ b/src/internals/core/Core.ts
@@ -1,38 +1,14 @@
+declare const rawArgs: unique symbol;
+type rawArgs = typeof rawArgs;
+
 export interface Fn {
-  args: unknown;
+  [rawArgs]: unknown;
+  args: this[rawArgs] extends infer args extends unknown[] ? args : never;
+  arg0: this[rawArgs] extends [infer arg, ...any] ? arg : never;
+  arg1: this[rawArgs] extends [any, infer arg, ...any] ? arg : never;
+  arg2: this[rawArgs] extends [any, any, infer arg, ...any] ? arg : never;
+  arg3: this[rawArgs] extends [any, any, any, infer arg, ...any] ? arg : never;
   return: unknown;
-}
-
-export namespace Fn {
-  export type args<F, Constraint extends unknown[] = unknown[]> = F extends {
-    args: infer args extends Constraint;
-  }
-    ? args
-    : never;
-
-  export type arg0<F, Constraint = unknown> = F extends {
-    args: [infer arg extends Constraint, ...any];
-  }
-    ? arg
-    : never;
-
-  export type arg1<F, Constraint = unknown> = F extends {
-    args: [any, infer arg extends Constraint, ...any];
-  }
-    ? arg
-    : never;
-
-  export type arg2<F, Constraint = unknown> = F extends {
-    args: [any, any, infer arg extends Constraint, ...any];
-  }
-    ? arg
-    : never;
-
-  export type arg3<F, Constraint = unknown> = F extends {
-    args: [any, any, any, infer arg extends Constraint, ...any];
-  }
-    ? arg
-    : never;
 }
 
 export type unset = "@hotscript/unset";
@@ -40,27 +16,27 @@ export type unset = "@hotscript/unset";
 export type _ = "@hotscript/placeholder";
 
 export type Apply<fn extends Fn, args extends unknown[]> = (fn & {
-  args: args;
+  [rawArgs]: args;
 })["return"];
 
 export type Call<fn extends Fn, arg1> = (fn & {
-  args: [arg1];
+  [rawArgs]: [arg1];
 })["return"];
 
 export type Eval<fn extends Fn> = (fn & {
-  args: [];
+  [rawArgs]: [];
 })["return"];
 
 export type Call2<fn extends Fn, arg1, arg2> = (fn & {
-  args: [arg1, arg2];
+  [rawArgs]: [arg1, arg2];
 })["return"];
 
 export type Call3<fn extends Fn, arg1, arg2, arg3> = (fn & {
-  args: [arg1, arg2, arg3];
+  [rawArgs]: [arg1, arg2, arg3];
 })["return"];
 
 export type Call4<fn extends Fn, arg1, arg2, arg3, arg4> = (fn & {
-  args: [arg1, arg2, arg3, arg4];
+  [rawArgs]: [arg1, arg2, arg3, arg4];
 })["return"];
 
 export type Call5<fn extends Fn, arg1, arg2, arg3, arg4, arg5> = (fn & {

--- a/src/internals/functions/Functions.ts
+++ b/src/internals/functions/Functions.ts
@@ -3,7 +3,7 @@ import { MergeArgs } from "./impl/MergeArgs";
 
 export namespace Functions {
   export interface Identity extends Fn {
-    return: Fn.arg0<this>;
+    return: this["arg0"];
   }
 
   export interface Constant<T> extends Fn {
@@ -15,17 +15,17 @@ export namespace Functions {
     : never;
 
   export interface Parameters extends Fn {
-    return: ParametersImpl<Fn.arg0<this>>;
+    return: ParametersImpl<this["arg0"]>;
   }
 
   export interface Parameter<N extends number> extends Fn {
-    return: ParametersImpl<Fn.arg0<this>>[N];
+    return: ParametersImpl<this["arg0"]>[N];
   }
 
   type ReturnImpl<fn> = fn extends (...args: any[]) => infer ret ? ret : never;
 
   export interface Return extends Fn {
-    return: ReturnImpl<Fn.arg0<this>>;
+    return: ReturnImpl<this["arg0"]>;
   }
 
   type Head<xs> = xs extends [infer first, ...any] ? first : never;
@@ -38,7 +38,7 @@ export namespace Functions {
     : Head<args>;
 
   export interface Compose<fns extends Fn[]> extends Fn {
-    return: ComposeImpl<fns, Fn.args<this>>;
+    return: ComposeImpl<fns, this["args"]>;
   }
 
   type ComposeLeftImpl<fns extends Fn[], args extends any[]> = fns extends [
@@ -49,13 +49,13 @@ export namespace Functions {
     : Head<args>;
 
   export interface ComposeLeft<fns extends Fn[]> extends Fn {
-    return: ComposeLeftImpl<fns, Fn.args<this>>;
+    return: ComposeLeftImpl<fns, this["args"]>;
   }
 
   export interface PartialApply<fn extends Fn, partialArgs extends unknown[]>
     extends Fn {
     return: MergeArgs<
-      Fn.args<this>,
+      this["args"],
       partialArgs
     > extends infer args extends unknown[]
       ? Apply<fn, args>

--- a/src/internals/numbers/Numbers.ts
+++ b/src/internals/numbers/Numbers.ts
@@ -21,7 +21,7 @@ export namespace Numbers {
   > = Functions.PartialApply<AddFn, [n1, n2]>;
 
   interface AddFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends number | bigint,
       infer b extends number | bigint,
       ...any
@@ -48,7 +48,7 @@ export namespace Numbers {
   > = Functions.PartialApply<SubFn, n2 extends unset ? [unset, n1] : [n1, n2]>;
 
   interface SubFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends number | bigint,
       infer b extends number | bigint,
       ...any
@@ -75,7 +75,7 @@ export namespace Numbers {
   > = Functions.PartialApply<MulFn, [n1, n2]>;
 
   interface MulFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends number | bigint,
       infer b extends number | bigint,
       ...any
@@ -102,7 +102,7 @@ export namespace Numbers {
   > = Functions.PartialApply<DivFn, n2 extends unset ? [unset, n1] : [n1, n2]>;
 
   interface DivFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends number | bigint,
       infer b extends number | bigint,
       ...any
@@ -129,7 +129,7 @@ export namespace Numbers {
   > = Functions.PartialApply<ModFn, [n1, n2]>;
 
   interface ModFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends number | bigint,
       infer b extends number | bigint,
       ...any
@@ -153,7 +153,7 @@ export namespace Numbers {
     Functions.PartialApply<NegateFn, [n]>;
 
   interface NegateFn extends Fn {
-    return: Fn.args<this> extends [infer a extends number | bigint, ...any]
+    return: this["args"] extends [infer a extends number | bigint, ...any]
       ? Impl.Negate<a>
       : never;
   }
@@ -173,7 +173,7 @@ export namespace Numbers {
     Functions.PartialApply<AbsFn, [n]>;
 
   export interface AbsFn extends Fn {
-    return: Fn.args<this> extends [infer a extends number | bigint, ...any]
+    return: this["args"] extends [infer a extends number | bigint, ...any]
       ? Impl.Abs<a>
       : never;
   }
@@ -198,7 +198,7 @@ export namespace Numbers {
   >;
 
   interface PowerFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends number | bigint,
       infer b extends number | bigint,
       ...any
@@ -229,7 +229,7 @@ export namespace Numbers {
   >;
 
   interface CompareFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends number | bigint,
       infer b extends number | bigint,
       ...any
@@ -259,7 +259,7 @@ export namespace Numbers {
   >;
 
   interface EqualFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends number | bigint,
       infer b extends number | bigint,
       ...any
@@ -289,7 +289,7 @@ export namespace Numbers {
   >;
 
   interface NotEqualFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends number | bigint,
       infer b extends number | bigint,
       ...any
@@ -320,7 +320,7 @@ export namespace Numbers {
   >;
 
   interface LessThanFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends number | bigint,
       infer b extends number | bigint,
       ...any
@@ -351,7 +351,7 @@ export namespace Numbers {
   >;
 
   interface LessThanOrEqualFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends number | bigint,
       infer b extends number | bigint,
       ...any
@@ -382,7 +382,7 @@ export namespace Numbers {
   >;
 
   interface GreaterThanFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends number | bigint,
       infer b extends number | bigint,
       ...any
@@ -413,7 +413,7 @@ export namespace Numbers {
   >;
 
   interface GreaterThanOrEqualFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends number | bigint,
       infer b extends number | bigint,
       ...any

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -15,7 +15,7 @@ export namespace Objects {
   };
 
   export interface FromEntries extends Fn {
-    return: FromEntriesImpl<Extract<Fn.arg0<this>, [PropertyKey, any]>>;
+    return: FromEntriesImpl<Extract<this["arg0"], [PropertyKey, any]>>;
   }
 
   type EntriesImpl<T> = {
@@ -23,7 +23,7 @@ export namespace Objects {
   }[keyof T];
 
   export interface Entries extends Fn {
-    return: EntriesImpl<Fn.arg0<this>>;
+    return: EntriesImpl<this["arg0"]>;
   }
 
   type MapValuesImpl<T, fn extends Fn> = {
@@ -31,7 +31,7 @@ export namespace Objects {
   };
 
   export interface MapValues<fn extends Fn> extends Fn {
-    return: MapValuesImpl<Fn.arg0<this>, fn>;
+    return: MapValuesImpl<this["arg0"], fn>;
   }
 
   type MapKeysImpl<T, fn extends Fn> = {
@@ -39,19 +39,19 @@ export namespace Objects {
   };
 
   export interface MapKeys<fn extends Fn> extends Fn {
-    return: MapKeysImpl<Fn.arg0<this>, fn>;
+    return: MapKeysImpl<this["arg0"], fn>;
   }
 
   export interface KebabCase extends Fn {
-    return: Call<MapKeys<Strings.KebabCase>, Fn.arg0<this>>;
+    return: Call<MapKeys<Strings.KebabCase>, this["arg0"]>;
   }
 
   export interface SnakeCase extends Fn {
-    return: Call<MapKeys<Strings.SnakeCase>, Fn.arg0<this>>;
+    return: Call<MapKeys<Strings.SnakeCase>, this["arg0"]>;
   }
 
   export interface CamelCase extends Fn {
-    return: Call<MapKeys<Strings.CamelCase>, Fn.arg0<this>>;
+    return: Call<MapKeys<Strings.CamelCase>, this["arg0"]>;
   }
 
   type MapKeysDeepImpl<T, fn extends Fn> = IsArrayStrict<T> extends true
@@ -65,19 +65,19 @@ export namespace Objects {
     : T;
 
   export interface MapKeysDeep<fn extends Fn> extends Fn {
-    return: MapKeysDeepImpl<Fn.arg0<this>, fn>;
+    return: MapKeysDeepImpl<this["arg0"], fn>;
   }
 
   export interface KebabCaseDeep extends Fn {
-    return: Call<MapKeysDeep<Strings.KebabCase>, Fn.arg0<this>>;
+    return: Call<MapKeysDeep<Strings.KebabCase>, this["arg0"]>;
   }
 
   export interface SnakeCaseDeep extends Fn {
-    return: Call<MapKeysDeep<Strings.SnakeCase>, Fn.arg0<this>>;
+    return: Call<MapKeysDeep<Strings.SnakeCase>, this["arg0"]>;
   }
 
   export interface CamelCaseDeep extends Fn {
-    return: Call<MapKeysDeep<Strings.CamelCase>, Fn.arg0<this>>;
+    return: Call<MapKeysDeep<Strings.CamelCase>, this["arg0"]>;
   }
 
   type PickImpl<obj, keys> = {
@@ -90,7 +90,7 @@ export namespace Objects {
   >;
 
   interface PickFn extends Fn {
-    return: PickImpl<Fn.arg1<this>, Fn.arg0<this>>;
+    return: PickImpl<this["arg1"], this["arg0"]>;
   }
 
   type OmitImpl<obj, keys> = {
@@ -103,7 +103,7 @@ export namespace Objects {
   >;
 
   interface OmitFn extends Fn {
-    return: OmitImpl<Fn.arg1<this>, Fn.arg0<this>>;
+    return: OmitImpl<this["arg1"], this["arg0"]>;
   }
 
   type PickEntriesImpl<
@@ -120,7 +120,7 @@ export namespace Objects {
   >;
 
   export interface PickBy<fn extends Fn> extends Fn {
-    return: PickByImpl<Fn.arg0<this>, fn>;
+    return: PickByImpl<this["arg0"], fn>;
   }
 
   type OmitEntriesImpl<
@@ -137,7 +137,7 @@ export namespace Objects {
   >;
 
   export interface OmitBy<fn extends Fn> extends Fn {
-    return: OmitByImpl<Fn.arg0<this>, fn>;
+    return: OmitByImpl<this["arg0"], fn>;
   }
 
   type AssignImpl<xs extends readonly any[]> = Prettify<
@@ -153,7 +153,7 @@ export namespace Objects {
   > = Functions.PartialApply<AssignFn, [arg1, arg2, arg3, arg4, arg5]>;
 
   interface AssignFn extends Fn {
-    return: AssignImpl<Fn.args<this>>;
+    return: AssignImpl<this["args"]>;
   }
 
   type GroupByImplRec<xs, fn extends Fn, acc = {}> = xs extends [
@@ -179,7 +179,7 @@ export namespace Objects {
   type GroupByImpl<xs, fn extends Fn> = Prettify<GroupByImplRec<xs, fn>>;
 
   export interface GroupBy<fn extends Fn> extends Fn {
-    return: GroupByImpl<Fn.arg0<this>, fn>;
+    return: GroupByImpl<this["arg0"], fn>;
   }
 
   export type Get<
@@ -188,7 +188,7 @@ export namespace Objects {
   > = Functions.PartialApply<GetFn, [path, obj]>;
 
   export interface GetFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer path extends string | number,
       infer obj,
       ...any

--- a/src/internals/strings/Strings.ts
+++ b/src/internals/strings/Strings.ts
@@ -27,7 +27,7 @@ export namespace Strings {
   export type Length<Str = unset> = Functions.PartialApply<LengthFn, [Str]>;
 
   export interface LengthFn extends Fn {
-    return: Impl.StringToTuple<Fn.arg0<this>>["length"];
+    return: Impl.StringToTuple<this["arg0"]>["length"];
   }
 
   /**
@@ -46,7 +46,7 @@ export namespace Strings {
   > = Functions.PartialApply<TrimLeftFn, [Sep, Str]>;
 
   interface TrimLeftFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer Sep extends string,
       infer Str extends string,
       ...any
@@ -71,7 +71,7 @@ export namespace Strings {
   > = Functions.PartialApply<TrimRightFn, [Sep, Str]>;
 
   interface TrimRightFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer Sep extends string,
       infer Str extends string,
       ...any
@@ -96,7 +96,7 @@ export namespace Strings {
   > = Functions.PartialApply<TrimFn, [Sep, Str]>;
 
   interface TrimFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer Sep extends string,
       infer Str extends string,
       ...any
@@ -122,7 +122,7 @@ export namespace Strings {
   > = Functions.PartialApply<ReplaceFn, [from, to, str]>;
 
   interface ReplaceFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer From extends string,
       infer To extends string,
       infer Str
@@ -166,7 +166,7 @@ export namespace Strings {
   > = Functions.PartialApply<SplitFn, [Sep, Str]>;
 
   export interface SplitFn extends Fn {
-    return: Fn.args<this> extends [infer Sep extends string, infer Str]
+    return: this["args"] extends [infer Sep extends string, infer Str]
       ? Impl.Split<Str, Sep>
       : never;
   }
@@ -187,7 +187,7 @@ export namespace Strings {
   > = Functions.PartialApply<RepeatFn, [Times, Str]>;
 
   interface RepeatFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer Times extends number,
       infer Str extends string
     ]
@@ -212,7 +212,7 @@ export namespace Strings {
   > = Functions.PartialApply<StartsWithFn, [Start, Str]>;
 
   interface StartsWithFn extends Fn {
-    return: Fn.args<this> extends [infer Start extends string, infer Str]
+    return: this["args"] extends [infer Start extends string, infer Str]
       ? Str extends `${Start}${string}`
         ? true
         : false
@@ -236,7 +236,7 @@ export namespace Strings {
   > = Functions.PartialApply<EndsWithFn, [End, Str]>;
 
   interface EndsWithFn extends Fn {
-    return: Fn.args<this> extends [infer End extends string, infer Str]
+    return: this["args"] extends [infer End extends string, infer Str]
       ? Str extends `${string}${End}`
         ? true
         : false
@@ -254,7 +254,7 @@ export namespace Strings {
    * ```
    */
   export interface ToTuple extends Fn {
-    return: Impl.StringToTuple<Fn.arg0<this>>;
+    return: Impl.StringToTuple<this["arg0"]>;
   }
 
   /**
@@ -268,7 +268,7 @@ export namespace Strings {
    * ```
    */
   export interface ToNumber extends Fn {
-    return: Fn.arg0<this> extends `${infer n extends number | bigint}`
+    return: this["arg0"] extends `${infer n extends number | bigint}`
       ? n
       : never;
   }
@@ -285,7 +285,7 @@ export namespace Strings {
    * ```
    */
   export interface ToString extends Fn {
-    return: `${Extract<Fn.arg0<this>, Strings.Stringifiable>}`;
+    return: `${Extract<this["arg0"], Strings.Stringifiable>}`;
   }
 
   /**
@@ -304,8 +304,8 @@ export namespace Strings {
   > = Functions.PartialApply<PrependFn, [Start, Str]>;
 
   interface PrependFn extends Fn {
-    return: `${Extract<Fn.arg0<this>, Strings.Stringifiable>}${Extract<
-      Fn.arg1<this>,
+    return: `${Extract<this["arg0"], Strings.Stringifiable>}${Extract<
+      this["arg1"],
       Strings.Stringifiable
     >}`;
   }
@@ -326,8 +326,8 @@ export namespace Strings {
   > = Functions.PartialApply<AppendFn, [End, Str]>;
 
   interface AppendFn extends Fn {
-    return: `${Extract<Fn.arg1<this>, Strings.Stringifiable>}${Extract<
-      Fn.arg0<this>,
+    return: `${Extract<this["arg1"], Strings.Stringifiable>}${Extract<
+      this["arg0"],
       Strings.Stringifiable
     >}`;
   }
@@ -342,7 +342,7 @@ export namespace Strings {
    * ```
    */
   export interface Uppercase extends Fn {
-    return: Std._Uppercase<Extract<Fn.arg0<this>, string>>;
+    return: Std._Uppercase<Extract<this["arg0"], string>>;
   }
 
   /**
@@ -355,7 +355,7 @@ export namespace Strings {
    * ```
    */
   export interface Lowercase extends Fn {
-    return: Std._Lowercase<Extract<Fn.arg0<this>, string>>;
+    return: Std._Lowercase<Extract<this["arg0"], string>>;
   }
 
   /**
@@ -368,7 +368,7 @@ export namespace Strings {
    * ```
    */
   export interface Capitalize extends Fn {
-    return: Std._Capitalize<Extract<Fn.arg0<this>, string>>;
+    return: Std._Capitalize<Extract<this["arg0"], string>>;
   }
 
   /**
@@ -381,7 +381,7 @@ export namespace Strings {
    * ```
    */
   export interface Uncapitalize extends Fn {
-    return: Std._Uncapitalize<Extract<Fn.arg0<this>, string>>;
+    return: Std._Uncapitalize<Extract<this["arg0"], string>>;
   }
 
   /**
@@ -394,7 +394,7 @@ export namespace Strings {
    * ```
    */
   export interface SnakeCase extends Fn {
-    return: H.SnakeCase<Fn.arg0<this>>;
+    return: H.SnakeCase<this["arg0"]>;
   }
 
   /**
@@ -407,7 +407,7 @@ export namespace Strings {
    * ```
    */
   export interface CamelCase extends Fn {
-    return: H.CamelCase<Fn.arg0<this>>;
+    return: H.CamelCase<this["arg0"]>;
   }
 
   /**
@@ -422,7 +422,7 @@ export namespace Strings {
    * ```
    */
   export interface KebabCase extends Fn {
-    return: H.KebabCase<Fn.arg0<this>>;
+    return: H.KebabCase<this["arg0"]>;
   }
 
   /**
@@ -448,7 +448,7 @@ export namespace Strings {
   >;
 
   interface CompareFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends string,
       infer b extends string,
       ...any
@@ -480,7 +480,7 @@ export namespace Strings {
   >;
 
   interface LessThanFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends string,
       infer b extends string,
       ...any
@@ -511,7 +511,7 @@ export namespace Strings {
   >;
 
   interface LessThanOrEqualFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends string,
       infer b extends string,
       ...any
@@ -543,7 +543,7 @@ export namespace Strings {
   >;
 
   interface GreaterThanFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends string,
       infer b extends string,
       ...any
@@ -575,7 +575,7 @@ export namespace Strings {
   >;
 
   interface GreaterThanOrEqualFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer a extends string,
       infer b extends string,
       ...any

--- a/src/internals/tuples/Tuples.ts
+++ b/src/internals/tuples/Tuples.ts
@@ -27,13 +27,16 @@ export namespace Tuples {
   > = Functions.PartialApply<AtFn, [index, tuple]>;
 
   interface AtFn extends Fn {
-    return: Fn.arg1<this, readonly any[]>[Fn.arg0<this, number>];
+    return: Extract<this["arg1"], readonly any[]>[Extract<
+      this["arg0"],
+      number
+    >];
   }
 
   type IsEmptyImpl<tuple extends unknown[]> = [] extends tuple ? true : false;
 
   interface CreateFn extends Fn {
-    return: Fn.args<this>;
+    return: this["args"];
   }
 
   /**
@@ -55,7 +58,7 @@ export namespace Tuples {
   > = Functions.PartialApply<CreateFn, [arg1, arg2, arg3, arg4, arg5]>;
 
   interface IsEmptyFn extends Fn {
-    return: IsEmptyImpl<Fn.arg0<this, unknown[]>>;
+    return: IsEmptyImpl<Extract<this["arg0"], unknown[]>>;
   }
 
   /**
@@ -90,7 +93,7 @@ export namespace Tuples {
     Functions.PartialApply<HeadFn, [tuple]>;
 
   interface HeadFn extends Fn {
-    return: HeadImpl<Fn.arg0<this>>;
+    return: HeadImpl<this["arg0"]>;
   }
 
   type TailImpl<xs> = xs extends readonly [any, ...infer tail] ? tail : [];
@@ -110,7 +113,7 @@ export namespace Tuples {
     Functions.PartialApply<TailFn, [tuple]>;
 
   export interface TailFn extends Fn {
-    return: TailImpl<Fn.arg0<this>>;
+    return: TailImpl<this["arg0"]>;
   }
 
   type LastImpl<xs> = xs extends readonly [...any, infer last] ? last : never;
@@ -130,11 +133,11 @@ export namespace Tuples {
     Functions.PartialApply<LastFn, [tuple]>;
 
   export interface LastFn extends Fn {
-    return: LastImpl<Fn.arg0<this>>;
+    return: LastImpl<this["arg0"]>;
   }
 
   interface MapReducer<fn extends Fn> extends Fn {
-    return: Fn.args<this> extends [infer acc extends any[], infer item]
+    return: this["args"] extends [infer acc extends any[], infer item]
       ? [...acc, Call<fn, item>]
       : never;
   }
@@ -156,11 +159,11 @@ export namespace Tuples {
   > = Functions.PartialApply<MapFn, [fn, tuple]>;
 
   interface MapFn extends Fn {
-    return: ReduceImpl<Fn.arg1<this>, [], MapReducer<Fn.arg0<this, Fn>>>;
+    return: ReduceImpl<this["arg1"], [], MapReducer<Extract<this["arg0"], Fn>>>;
   }
 
   interface FlatMapReducer<fn extends Fn> extends Fn {
-    return: Fn.args<this> extends [infer acc extends any[], infer item]
+    return: this["args"] extends [infer acc extends any[], infer item]
       ? [...acc, ...Extract<Call<fn, item>, readonly any[]>]
       : never;
   }
@@ -182,7 +185,11 @@ export namespace Tuples {
   > = Functions.PartialApply<FlatMapFn, [fn, tuple]>;
 
   interface FlatMapFn extends Fn {
-    return: ReduceImpl<Fn.arg1<this>, [], FlatMapReducer<Fn.arg0<this, Fn>>>;
+    return: ReduceImpl<
+      this["arg1"],
+      [],
+      FlatMapReducer<Extract<this["arg0"], Fn>>
+    >;
   }
 
   type ReduceImpl<xs, acc, fn extends Fn> = xs extends [
@@ -211,7 +218,7 @@ export namespace Tuples {
   > = Functions.PartialApply<ReduceFn, [fn, init, tuple]>;
 
   interface ReduceFn extends Fn {
-    return: ReduceImpl<Fn.arg2<this>, Fn.arg1<this>, Fn.arg0<this, Fn>>;
+    return: ReduceImpl<this["arg2"], this["arg1"], Extract<this["arg0"], Fn>>;
   }
 
   type ReduceRightImpl<xs, acc, fn extends Fn> = xs extends [
@@ -240,11 +247,15 @@ export namespace Tuples {
   > = Functions.PartialApply<ReduceRightFn, [fn, init, tuple]>;
 
   interface ReduceRightFn extends Fn {
-    return: ReduceRightImpl<Fn.arg2<this>, Fn.arg1<this>, Fn.arg0<this, Fn>>;
+    return: ReduceRightImpl<
+      this["arg2"],
+      this["arg1"],
+      Extract<this["arg0"], Fn>
+    >;
   }
 
   interface FilterReducer<fn extends Fn> extends Fn {
-    return: Fn.args<this> extends [infer acc extends any[], infer item]
+    return: this["args"] extends [infer acc extends any[], infer item]
       ? Call<fn, item> extends true
         ? [...acc, item]
         : acc
@@ -268,7 +279,11 @@ export namespace Tuples {
   > = Functions.PartialApply<FilterFn, [fn, tuple]>;
 
   export interface FilterFn extends Fn {
-    return: ReduceImpl<Fn.arg1<this>, [], FilterReducer<Fn.arg0<this, Fn>>>;
+    return: ReduceImpl<
+      this["arg1"],
+      [],
+      FilterReducer<Extract<this["arg0"], Fn>>
+    >;
   }
 
   type FindImpl<xs, fn extends Fn, index extends any[] = []> = xs extends [
@@ -297,7 +312,7 @@ export namespace Tuples {
   > = Functions.PartialApply<FindFn, [fn, tuple]>;
 
   export interface FindFn extends Fn {
-    return: FindImpl<Fn.arg1<this>, Fn.arg0<this, Fn>>;
+    return: FindImpl<this["arg1"], Extract<this["arg0"], Fn>>;
   }
 
   /**
@@ -314,7 +329,7 @@ export namespace Tuples {
     Functions.PartialApply<SumFn, [tuple]>;
 
   interface SumFn extends Fn {
-    return: ReduceImpl<Fn.arg0<this>, 0, N.Add>;
+    return: ReduceImpl<this["arg0"], 0, N.Add>;
   }
 
   type DropImpl<
@@ -344,7 +359,7 @@ export namespace Tuples {
   > = Functions.PartialApply<DropFn, [n, tuple]>;
 
   export interface DropFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer N extends number,
       infer T extends readonly any[]
     ]
@@ -380,7 +395,7 @@ export namespace Tuples {
   > = Functions.PartialApply<TakeFn, [n, tuple]>;
 
   interface TakeFn extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer N extends number,
       infer T extends readonly any[]
     ]
@@ -416,7 +431,10 @@ export namespace Tuples {
   >;
 
   export interface TakeWhileFn extends Fn {
-    return: TakeWhileImpl<Fn.arg1<this, readonly any[]>, Fn.arg0<this, Fn>>;
+    return: TakeWhileImpl<
+      Extract<this["arg1"], readonly any[]>,
+      Extract<this["arg0"], Fn>
+    >;
   }
 
   /**
@@ -436,8 +454,8 @@ export namespace Tuples {
   >;
   export interface SomeFn extends Fn {
     return: true extends Call<
-      Tuples.Map<Fn.arg0<this, Fn>>,
-      Fn.arg1<this>
+      Tuples.Map<Extract<this["arg0"], Fn>>,
+      this["arg1"]
     >[number]
       ? true
       : false;
@@ -461,8 +479,8 @@ export namespace Tuples {
   >;
   export interface EveryFn extends Fn {
     return: false extends Call<
-      Tuples.Map<Fn.arg0<this, Fn>>,
-      Fn.arg1<this>
+      Tuples.Map<Extract<this["arg0"], Fn>>,
+      this["arg1"]
     >[number]
       ? false
       : true;
@@ -502,13 +520,13 @@ export namespace Tuples {
    * ```
    */
   export interface Sort<predicateFn extends Fn = N.LessThanOrEqual> extends Fn {
-    return: Fn.args<this> extends [infer xs extends any[]]
+    return: this["args"] extends [infer xs extends any[]]
       ? SortImpl<xs, predicateFn>
       : never;
   }
 
   interface JoinReducer<sep extends string> extends Fn {
-    return: Fn.args<this> extends [
+    return: this["args"] extends [
       infer acc extends Stringifiable,
       infer item extends Stringifiable
     ]
@@ -534,7 +552,7 @@ export namespace Tuples {
   > = Functions.PartialApply<JoinFn, [Sep, Tuple]>;
 
   interface JoinFn extends Fn {
-    return: Fn.args<this> extends [infer Sep extends string, infer Tuple]
+    return: this["args"] extends [infer Sep extends string, infer Tuple]
       ? ReduceImpl<Tuple, "", JoinReducer<Sep>>
       : never;
   }
@@ -555,7 +573,7 @@ export namespace Tuples {
   >;
 
   interface PrependFn extends Fn {
-    return: Fn.args<this> extends [infer element, infer tuple extends any[]]
+    return: this["args"] extends [infer element, infer tuple extends any[]]
       ? [element, ...tuple]
       : never;
   }
@@ -575,7 +593,7 @@ export namespace Tuples {
   >;
 
   interface AppendFn extends Fn {
-    return: Fn.args<this> extends [infer element, infer tuple extends any[]]
+    return: this["args"] extends [infer element, infer tuple extends any[]]
       ? [...tuple, element]
       : never;
   }
@@ -611,7 +629,10 @@ export namespace Tuples {
     : [left, right];
 
   interface PartitionFn extends Fn {
-    return: PartitionImpl<Fn.arg0<this, Fn>, Fn.arg1<this, any[]>>;
+    return: PartitionImpl<
+      Extract<this["arg0"], Fn>,
+      Extract<this["arg1"], any[]>
+    >;
   }
 
   type ZipWithImpl<
@@ -627,7 +648,11 @@ export namespace Tuples {
     : acc;
 
   interface ZipWithFn<fn extends Fn> extends Fn {
-    return: ZipWithImpl<Fn.arg0<this, unknown[]>, Fn.arg1<this, unknown[]>, fn>;
+    return: ZipWithImpl<
+      Extract<this["arg0"], unknown[]>,
+      Extract<this["arg1"], unknown[]>,
+      fn
+    >;
   }
 
   /**

--- a/src/internals/unions/Unions.ts
+++ b/src/internals/unions/Unions.ts
@@ -14,7 +14,7 @@ export namespace Unions {
   >;
 
   interface ExtractFn extends Fn {
-    return: Std._Extract<Fn.arg0<this>, Fn.arg1<this>>;
+    return: Std._Extract<this["arg0"], this["arg1"]>;
   }
 
   type ExtractByImpl<union, predicate extends Fn> = union extends any
@@ -24,7 +24,7 @@ export namespace Unions {
     : never;
 
   export interface ExtractBy<predicate extends Fn> extends Fn {
-    return: ExtractByImpl<Fn.arg0<this>, predicate>;
+    return: ExtractByImpl<this["arg0"], predicate>;
   }
 
   export type Exclude<
@@ -38,7 +38,7 @@ export namespace Unions {
   >;
 
   interface ExcludeFn extends Fn {
-    return: Std._Exclude<Fn.arg0<this>, Fn.arg1<this>>;
+    return: Std._Exclude<this["arg0"], this["arg1"]>;
   }
 
   type ExcludeByImpl<union, predicate extends Fn> = union extends any
@@ -48,7 +48,7 @@ export namespace Unions {
     : never;
 
   export interface ExcludeBy<predicate extends Fn> extends Fn {
-    return: ExcludeByImpl<Fn.arg0<this>, predicate>;
+    return: ExcludeByImpl<this["arg0"], predicate>;
   }
 
   type MapImpl<fn extends Fn, union> = union extends any
@@ -60,6 +60,8 @@ export namespace Unions {
     [fn, u]
   >;
   interface MapFn extends Fn {
-    return: MapImpl<Fn.arg0<this, Fn>, Fn.arg1<this>>;
+    return: this["args"] extends [infer fn extends Fn, infer u]
+      ? MapImpl<fn, u>
+      : never;
   }
 }

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -2,12 +2,9 @@ import {
   Pipe,
   PipeRight,
   Call,
-  Call2,
   Numbers,
   Strings,
   Tuples,
-  O,
-  N,
   F,
   _,
 } from "../src/index";

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -330,7 +330,7 @@ describe("Objects", () => {
 
   describe("GroupBy", () => {
     interface GetTypeKey extends Fn {
-      return: Fn.arg0<this> extends { type: infer Type } ? Type : never;
+      return: this["arg0"] extends { type: infer Type } ? Type : never;
     }
     type res1 = Call<
       // ^?

--- a/test/tuples.test.ts
+++ b/test/tuples.test.ts
@@ -56,7 +56,7 @@ describe("Tuples", () => {
 
   it("Map", () => {
     interface ToPhrase extends Fn {
-      return: `number is ${Extract<Fn.arg0<this>, string | number | boolean>}`;
+      return: `number is ${Extract<this["arg0"], string | number | boolean>}`;
     }
 
     type res1 = Call<Tuples.Map<ToPhrase>, [1, 2, 3]>;
@@ -74,7 +74,7 @@ describe("Tuples", () => {
 
   it("Filter", () => {
     interface IsNumber extends Fn {
-      return: Fn.arg0<this> extends number ? true : false;
+      return: this["arg0"] extends number ? true : false;
     }
 
     type res1 = Call<Tuples.Filter<IsNumber>, [1, 2, "oops", 3]>;
@@ -88,7 +88,7 @@ describe("Tuples", () => {
 
   it("Reduce", () => {
     interface ToUnaryTupleArray extends Fn {
-      return: Fn.args<this> extends [infer acc extends any[], infer item]
+      return: this["args"] extends [infer acc extends any[], infer item]
         ? [...acc, [item]]
         : never;
     }
@@ -104,7 +104,7 @@ describe("Tuples", () => {
 
   it("ReduceRight", () => {
     interface ToUnaryTupleArray extends Fn {
-      return: Fn.args<this> extends [infer acc extends any[], infer item]
+      return: this["args"] extends [infer acc extends any[], infer item]
         ? [...acc, [item]]
         : never;
     }
@@ -123,7 +123,7 @@ describe("Tuples", () => {
 
   it("FlatMap", () => {
     interface Duplicate extends Fn {
-      return: [Fn.arg0<this>, Fn.arg0<this>];
+      return: [this["arg0"], this["arg0"]];
     }
 
     type res1 = Call<Tuples.FlatMap<Duplicate>, [1, 2, 3]>;
@@ -137,7 +137,7 @@ describe("Tuples", () => {
 
   it("Find", () => {
     interface IsNumber extends Fn {
-      return: Fn.arg0<this> extends number ? true : false;
+      return: this["arg0"] extends number ? true : false;
     }
 
     type res1 = Call<Tuples.Find<IsNumber>, ["a", "b", "c", 2, "d"]>;
@@ -145,7 +145,7 @@ describe("Tuples", () => {
     type tes1 = Expect<Equal<res1, 2>>;
 
     interface IsSecond extends Fn {
-      return: Fn.arg1<this> extends 1 ? true : false;
+      return: this["arg1"] extends 1 ? true : false;
     }
 
     type res2 = Call<Tuples.Find<IsSecond>, ["a", "b", "c", 2, "d"]>;
@@ -395,7 +395,7 @@ describe("Tuples", () => {
 
   it("Composition", () => {
     interface Duplicate extends Fn {
-      return: [Fn.arg0<this>, Fn.arg0<this>];
+      return: [this["arg0"], this["arg0"]];
     }
 
     // prettier-ignore

--- a/test/unions.test.ts
+++ b/test/unions.test.ts
@@ -30,7 +30,7 @@ describe("Unions", () => {
 
   it("Map", () => {
     interface ToTuple extends Fn {
-      return: [Fn.arg0<this>];
+      return: [this["arg0"]];
     }
 
     type res1 = Pipe<"a" | "b" | "c", [U.Map<ToTuple>]>;


### PR DESCRIPTION
Doesn't it look more intuitive like this? 

Type-checking performance is the same