### PR TITLE
added basic pattern matching

### DIFF
--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -196,4 +196,32 @@ export namespace Objects {
       ? GetFromPath<obj, path>
       : never;
   }
+
+  export type With<match, fn extends Fn> = { match: match; fn: fn };
+
+  /**
+   * Type-level pattern matching
+   * @param value the value to pattern match on
+   * @param patterns the possible patterns
+   *
+   * @example
+   * ```ts
+   * type Test<T> = Match<T, [
+   *   With<{ msg: string }, F.ComposeLeft<[O.Get<"msg">, S.Prepend<"Message: ">]>>,
+   *   With<string, S.Append<" <-- Message">>,
+   *   With<any, F.Constant<"default value">>
+   * ]>
+   * ```
+   */
+  export type Match<
+    value,
+    patterns extends With<any, any>[]
+  > = patterns extends [
+    With<infer match, infer fn extends Fn>,
+    ...infer restPatterns extends With<any, any>[]
+  ]
+    ? value extends match
+      ? Call<fn, value>
+      : Match<value, restPatterns>
+    : never;
 }

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -213,7 +213,7 @@ export namespace Objects {
    * ]>
    * ```
    */
-  export type Match<
+  type MatchImpl<
     value,
     patterns extends With<any, any>[]
   > = patterns extends [
@@ -222,6 +222,13 @@ export namespace Objects {
   ]
     ? value extends match
       ? Call<fn, value>
-      : Match<value, restPatterns>
+      : MatchImpl<value, restPatterns>
     : never;
+
+	export interface MatchFn extends Fn {
+		return: MatchImpl<this['arg0'], this['arg1']>;
+	}
+
+	export type Match<value = unset, patterns extends With<unknown, any>[] | _ | unset = unset> =
+  Functions.PartialApply<MatchFn, [value, patterns]>;
 }

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -213,10 +213,7 @@ export namespace Objects {
    * ]>
    * ```
    */
-  type MatchImpl<
-    value,
-    patterns extends With<any, any>[]
-  > = patterns extends [
+  type MatchImpl<value, patterns extends With<any, any>[]> = patterns extends [
     With<infer match, infer fn extends Fn>,
     ...infer restPatterns extends With<any, any>[]
   ]
@@ -225,10 +222,12 @@ export namespace Objects {
       : MatchImpl<value, restPatterns>
     : never;
 
-	export interface MatchFn extends Fn {
-		return: MatchImpl<this['arg0'], this['arg1']>;
-	}
+  export interface MatchFn extends Fn {
+    return: MatchImpl<this["arg0"], this["arg1"]>;
+  }
 
-	export type Match<value = unset, patterns extends With<unknown, any>[] | _ | unset = unset> =
-  Functions.PartialApply<MatchFn, [value, patterns]>;
+  export type Match<
+    value = unset,
+    patterns extends With<any, any>[] | _ | unset = unset
+  > = Functions.PartialApply<MatchFn, [value, patterns]>;
 }

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -1,6 +1,7 @@
 import { Booleans } from "../src/internals/booleans/Booleans";
 import { Call, Eval, Fn, Pipe } from "../src/internals/core/Core";
 import { Strings } from "../src/internals/strings/Strings";
+import { Functions } from "../src/internals/functions/Functions";
 import { Objects } from "../src/internals/objects/Objects";
 import { Tuples } from "../src/internals/tuples/Tuples";
 import { Equal, Expect } from "../src/internals/helpers";
@@ -365,4 +366,16 @@ describe("Objects", () => {
       >
     >;
   });
+
+	describe("Match", () => {
+		type MatchTest<T> = Objects.Match<T, [
+			Objects.With<{ msg: string }, Functions.Constant<"a">>,
+			Objects.With<string, Functions.Constant<"b">>,
+			Objects.With<any, Functions.Constant<"c">>
+		]>
+
+		type R1 = Expect<Equal<MatchTest<{ msg: "hello" }>, "a">>
+		type R2 = Expect<Equal<MatchTest<"hello">, "b">>
+		type R3 = Expect<Equal<MatchTest<1>, "c">>
+	})
 });

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -367,15 +367,20 @@ describe("Objects", () => {
     >;
   });
 
-	describe("Match", () => {
-		type MatchTest<T> = Eval<Objects.Match<T, [
-			Objects.With<{ msg: string }, Functions.Constant<"a">>,
-			Objects.With<string, Functions.Constant<"b">>,
-			Objects.With<any, Functions.Constant<"c">>
-		]>>
+  describe("Match", () => {
+    type MatchTest<T> = Eval<
+      Objects.Match<
+        T,
+        [
+          Objects.With<{ msg: string }, Functions.Constant<"a">>,
+          Objects.With<string, Functions.Constant<"b">>,
+          Objects.With<any, Functions.Constant<"c">>
+        ]
+      >
+    >;
 
-		type R1 = Expect<Equal<MatchTest<{ msg: "hello" }>, "a">>
-		type R2 = Expect<Equal<MatchTest<"hello">, "b">>
-		type R3 = Expect<Equal<MatchTest<1>, "c">>
-	})
+    type R1 = Expect<Equal<MatchTest<{ msg: "hello" }>, "a">>;
+    type R2 = Expect<Equal<MatchTest<"hello">, "b">>;
+    type R3 = Expect<Equal<MatchTest<1>, "c">>;
+  });
 });

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -368,11 +368,11 @@ describe("Objects", () => {
   });
 
 	describe("Match", () => {
-		type MatchTest<T> = Objects.Match<T, [
+		type MatchTest<T> = Eval<Objects.Match<T, [
 			Objects.With<{ msg: string }, Functions.Constant<"a">>,
 			Objects.With<string, Functions.Constant<"b">>,
 			Objects.With<any, Functions.Constant<"c">>
-		]>
+		]>>
 
 		type R1 = Expect<Equal<MatchTest<{ msg: "hello" }>, "a">>
 		type R2 = Expect<Equal<MatchTest<"hello">, "b">>


### PR DESCRIPTION
added the ability to pattern match

example:
```ts
type Test<T> = Match<T, [
  With<{ msg: string }, F.ComposeLeft<[O.Get<"msg">, S.Prepend<"Message: ">]>>,
  With<string, S.Append<" <-- Message">>,
  With<any, F.Constant<"default value">>
]>
```