### PR TITLE
feat(match): Add pattern matching with destructuring

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { Strings } from "./internals/strings/Strings";
 import { Tuples } from "./internals/tuples/Tuples";
 import { Unions } from "./internals/unions/Unions";
 import { Booleans } from "./internals/booleans/Booleans";
+import { Match } from "./internals/match/Match";
 
 export {
   _,
@@ -32,6 +33,7 @@ export {
   Numbers,
   Tuples,
   Functions,
+  Match,
   Booleans as B,
   Objects as O,
   Unions as U,

--- a/src/internals/helpers.ts
+++ b/src/internals/helpers.ts
@@ -222,3 +222,12 @@ export type Stringifiable =
   | bigint
   | null
   | undefined;
+
+export type Primitive =
+  | string
+  | number
+  | boolean
+  | bigint
+  | null
+  | undefined
+  | symbol;

--- a/src/internals/match/Match.ts
+++ b/src/internals/match/Match.ts
@@ -21,9 +21,14 @@ import * as Impl from "./impl/match";
  * ```
  */
 export type Match<
-  value = unset,
-  withClauses extends Match.With<any, any>[] | _ | unset = unset
-> = Functions.PartialApply<MatchFn, [value, withClauses]>;
+  valueOrWithClauses = unset,
+  withClauses = unset
+> = Functions.PartialApply<
+  MatchFn,
+  withClauses extends unset
+    ? [unset, valueOrWithClauses]
+    : [valueOrWithClauses, withClauses]
+>;
 
 interface MatchFn extends Fn {
   return: Impl.Match<this["arg0"], this["arg1"]>;

--- a/src/internals/match/Match.ts
+++ b/src/internals/match/Match.ts
@@ -1,0 +1,39 @@
+import { Fn, unset, _ } from "../core/Core";
+import { Functions } from "../functions/Functions";
+import * as Impl from "./impl/match";
+
+/**
+ * Match creates a pattern matching expression.
+ * Pattern matching let you execute different
+ * branches of code based on the structure
+ * of the input type exdestructure the input type, and execute
+ *
+ * @param input - the input to pattern match on
+ * @param withClauses - list of with clauses representing different branches if code
+ *
+ * @example
+ * ```ts
+ * type Test<T> = Match<T, [
+ *   With<{ msg: string }, F.ComposeLeft<[O.Get<"msg">, S.Prepend<"Message: ">]>>,
+ *   With<string, S.Append<" <-- Message">>,
+ *   With<any, F.Constant<"default value">>
+ * ]>
+ * ```
+ */
+export type Match<
+  value = unset,
+  patterns extends Match.With<any, any>[] | _ | unset = unset
+> = Functions.PartialApply<MatchFn, [value, patterns]>;
+
+interface MatchFn extends Fn {
+  return: Impl.Match<this["arg0"], this["arg1"]>;
+}
+
+export namespace Match {
+  export type With<pattern, fn extends Fn> = Impl.With<pattern, fn>;
+
+  export type arg0 = Impl.arg0;
+  export type arg1 = Impl.arg1;
+  export type arg2 = Impl.arg2;
+  export type arg3 = Impl.arg3;
+}

--- a/src/internals/match/Match.ts
+++ b/src/internals/match/Match.ts
@@ -32,8 +32,8 @@ interface MatchFn extends Fn {
 export namespace Match {
   export type With<pattern, fn extends Fn> = Impl.With<pattern, fn>;
 
-  export type arg0 = Impl.arg0;
-  export type arg1 = Impl.arg1;
-  export type arg2 = Impl.arg2;
-  export type arg3 = Impl.arg3;
+  export type arg0<Constraint = unknown> = Impl.arg<0, Constraint>;
+  export type arg1<Constraint = unknown> = Impl.arg<1, Constraint>;
+  export type arg2<Constraint = unknown> = Impl.arg<2, Constraint>;
+  export type arg3<Constraint = unknown> = Impl.arg<3, Constraint>;
 }

--- a/src/internals/match/Match.ts
+++ b/src/internals/match/Match.ts
@@ -14,15 +14,15 @@ import * as Impl from "./impl/match";
  * @example
  * ```ts
  * type Test<T> = Match<T, [
- *   With<{ msg: string }, F.ComposeLeft<[O.Get<"msg">, S.Prepend<"Message: ">]>>,
- *   With<string, S.Append<" <-- Message">>,
+ *   With<{ msg: Match.arg0 }, S.Prepend<"Message: ">>,
+ *   With<string, S.Append<": string">>,
  *   With<any, F.Constant<"default value">>
  * ]>
  * ```
  */
 export type Match<
   valueOrWithClauses = unset,
-  withClauses = unset
+  withClauses extends Impl.With<unknown, any>[] | unset | _ = unset
 > = Functions.PartialApply<
   MatchFn,
   withClauses extends unset

--- a/src/internals/match/Match.ts
+++ b/src/internals/match/Match.ts
@@ -22,8 +22,8 @@ import * as Impl from "./impl/match";
  */
 export type Match<
   value = unset,
-  patterns extends Match.With<any, any>[] | _ | unset = unset
-> = Functions.PartialApply<MatchFn, [value, patterns]>;
+  withClauses extends Match.With<any, any>[] | _ | unset = unset
+> = Functions.PartialApply<MatchFn, [value, withClauses]>;
 
 interface MatchFn extends Fn {
   return: Impl.Match<this["arg0"], this["arg1"]>;

--- a/src/internals/match/Match.ts
+++ b/src/internals/match/Match.ts
@@ -41,4 +41,8 @@ export namespace Match {
   export type arg1<Constraint = unknown> = Impl.arg<1, Constraint>;
   export type arg2<Constraint = unknown> = Impl.arg<2, Constraint>;
   export type arg3<Constraint = unknown> = Impl.arg<3, Constraint>;
+  export type arg<Index extends number, Constraint = unknown> = Impl.arg<
+    Index,
+    Constraint
+  >;
 }

--- a/src/internals/match/impl/match.ts
+++ b/src/internals/match/impl/match.ts
@@ -2,35 +2,34 @@ import { Eval, Fn, unset } from "../../core/Core";
 import { Functions } from "../../functions/Functions";
 import { Primitive, UnionToIntersection } from "../../helpers";
 
-export type arg0 = "@hotscript/arg0";
-export type arg1 = "@hotscript/arg1";
-export type arg2 = "@hotscript/arg2";
-export type arg3 = "@hotscript/arg3";
+export type arg<Index extends number, Constraint = unknown> = {
+  tag: "@hotscript/arg";
+  index: Index;
+  constraint: Constraint;
+};
 
 type GetWithDefault<Obj, K, Def> = K extends keyof Obj ? Obj[K] : Def;
 
-type ReplaceArgsWithAny<pattern> = pattern extends arg0 | arg1 | arg2 | arg3
-  ? any
+type ReplaceArgsWithConstraint<pattern> = pattern extends arg<
+  any,
+  infer Constraint
+>
+  ? Constraint
   : pattern extends Primitive
   ? pattern
   : pattern extends [any, ...any]
-  ? { [key in keyof pattern]: ReplaceArgsWithAny<pattern[key]> }
+  ? { [key in keyof pattern]: ReplaceArgsWithConstraint<pattern[key]> }
   : pattern extends (infer V)[]
-  ? ReplaceArgsWithAny<V>[]
+  ? ReplaceArgsWithConstraint<V>[]
   : pattern extends object
-  ? { [key in keyof pattern]: ReplaceArgsWithAny<pattern[key]> }
+  ? { [key in keyof pattern]: ReplaceArgsWithConstraint<pattern[key]> }
   : pattern;
 
-type DoesMatch<value, pattern> = value extends ReplaceArgsWithAny<pattern>
-  ? true
-  : false;
+type DoesMatch<value, pattern> =
+  value extends ReplaceArgsWithConstraint<pattern> ? true : false;
 
-type ExtractArgObject<value, pattern> = pattern extends
-  | arg0
-  | arg1
-  | arg2
-  | arg3
-  ? { [K in pattern]: value }
+type ExtractArgObject<value, pattern> = pattern extends arg<infer N, any>
+  ? { [K in N]: value }
   : pattern extends []
   ? {}
   : [value, pattern] extends [
@@ -57,10 +56,10 @@ type WithDefaultArgs<Args extends any[], Def> = [Args[number]] extends [unset]
   : Args;
 
 type ArgObjectToArgs<T> = [
-  GetWithDefault<T, arg0, unset>,
-  GetWithDefault<T, arg1, unset>,
-  GetWithDefault<T, arg2, unset>,
-  GetWithDefault<T, arg3, unset>
+  GetWithDefault<T, 0, unset>,
+  GetWithDefault<T, 1, unset>,
+  GetWithDefault<T, 2, unset>,
+  GetWithDefault<T, 3, unset>
 ];
 
 type ExtractArgs<value, pattern> = WithDefaultArgs<

--- a/src/internals/match/impl/match.ts
+++ b/src/internals/match/impl/match.ts
@@ -1,0 +1,83 @@
+import { Eval, Fn, unset } from "../../core/Core";
+import { Functions } from "../../functions/Functions";
+import { Primitive, UnionToIntersection } from "../../helpers";
+
+export type arg0 = "@hotscript/arg0";
+export type arg1 = "@hotscript/arg1";
+export type arg2 = "@hotscript/arg2";
+export type arg3 = "@hotscript/arg3";
+
+type GetWithDefault<Obj, K, Def> = K extends keyof Obj ? Obj[K] : Def;
+
+type ReplaceArgsWithAny<pattern> = pattern extends arg0 | arg1 | arg2 | arg3
+  ? any
+  : pattern extends Primitive
+  ? pattern
+  : pattern extends [any, ...any]
+  ? { [key in keyof pattern]: ReplaceArgsWithAny<pattern[key]> }
+  : pattern extends (infer V)[]
+  ? ReplaceArgsWithAny<V>[]
+  : pattern extends object
+  ? { [key in keyof pattern]: ReplaceArgsWithAny<pattern[key]> }
+  : pattern;
+
+type DoesMatch<value, pattern> = value extends ReplaceArgsWithAny<pattern>
+  ? true
+  : false;
+
+type ExtractArgObject<value, pattern> = pattern extends
+  | arg0
+  | arg1
+  | arg2
+  | arg3
+  ? { [K in pattern]: value }
+  : pattern extends []
+  ? {}
+  : [value, pattern] extends [
+      [infer valueFirst, ...infer valueRest],
+      [infer patternFirst, ...infer patternRest]
+    ]
+  ? ExtractArgObject<valueRest, patternRest> &
+      ExtractArgObject<valueFirst, patternFirst>
+  : [value, pattern] extends [(infer valueFirst)[], (infer patternFirst)[]]
+  ? ExtractArgObject<valueFirst, patternFirst>
+  : [value, pattern] extends [object, object]
+  ? UnionToIntersection<
+      {
+        [k in keyof value & keyof pattern]: ExtractArgObject<
+          value[k],
+          pattern[k]
+        >;
+      }[keyof value & keyof pattern]
+    >
+  : {};
+
+type WithDefaultArgs<Args extends any[], Def> = [Args[number]] extends [unset]
+  ? Def
+  : Args;
+
+type ArgObjectToArgs<T> = [
+  GetWithDefault<T, arg0, unset>,
+  GetWithDefault<T, arg1, unset>,
+  GetWithDefault<T, arg2, unset>,
+  GetWithDefault<T, arg3, unset>
+];
+
+type ExtractArgs<value, pattern> = WithDefaultArgs<
+  ArgObjectToArgs<ExtractArgObject<value, pattern>>,
+  [value]
+>;
+
+export type Match<
+  value,
+  patterns extends With<unknown, any>[]
+> = patterns extends [
+  With<infer pattern, infer fn extends Fn>,
+  ...infer restPatterns extends With<unknown, Fn>[]
+]
+  ? DoesMatch<value, pattern> extends true
+    ? Eval<Functions.PartialApply<fn, ExtractArgs<value, pattern>>>
+    : Match<value, restPatterns>
+  : never;
+
+export type With<pattern, fn extends Fn> = { pattern: pattern; fn: fn };

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -196,38 +196,4 @@ export namespace Objects {
       ? GetFromPath<obj, path>
       : never;
   }
-
-  export type With<match, fn extends Fn> = { match: match; fn: fn };
-
-  /**
-   * Type-level pattern matching
-   * @param value the value to pattern match on
-   * @param patterns the possible patterns
-   *
-   * @example
-   * ```ts
-   * type Test<T> = Match<T, [
-   *   With<{ msg: string }, F.ComposeLeft<[O.Get<"msg">, S.Prepend<"Message: ">]>>,
-   *   With<string, S.Append<" <-- Message">>,
-   *   With<any, F.Constant<"default value">>
-   * ]>
-   * ```
-   */
-  type MatchImpl<value, patterns extends With<any, any>[]> = patterns extends [
-    With<infer match, infer fn extends Fn>,
-    ...infer restPatterns extends With<any, any>[]
-  ]
-    ? value extends match
-      ? Call<fn, value>
-      : MatchImpl<value, restPatterns>
-    : never;
-
-  export interface MatchFn extends Fn {
-    return: MatchImpl<this["arg0"], this["arg1"]>;
-  }
-
-  export type Match<
-    value = unset,
-    patterns extends With<any, any>[] | _ | unset = unset
-  > = Functions.PartialApply<MatchFn, [value, patterns]>;
 }

--- a/test/match.test.ts
+++ b/test/match.test.ts
@@ -1,0 +1,71 @@
+import { Eval, Functions, Match, Numbers, Strings } from "../src";
+import { Equal, Expect } from "../src/internals/helpers";
+
+describe("Match", () => {
+  it("should match with regular types", () => {
+    type MatchTest<T> = Eval<
+      Match<
+        T,
+        [
+          Match.With<{ msg: string }, Functions.Constant<"a">>,
+          Match.With<string, Functions.Constant<"b">>,
+          Match.With<any, Functions.Constant<"c">>
+        ]
+      >
+    >;
+
+    type res1 = MatchTest<{ msg: "hello" }>;
+    //    ^?
+
+    type test1 = Expect<Equal<res1, "a">>;
+    type res2 = MatchTest<"hello">;
+    //    ^?
+
+    type test2 = Expect<Equal<res2, "b">>;
+    type res3 = MatchTest<1>;
+    //    ^?
+
+    type test3 = Expect<Equal<res3, "c">>;
+  });
+
+  it("should work with patterns destructuring arguments", () => {
+    type MatchTest<T> = Eval<
+      Match<
+        T,
+        [
+          Match.With<
+            { nested: { value: Match.arg0 } },
+            Strings.Prepend<"nested.value === ">
+          >,
+          Match.With<{ x: Match.arg0; y: Match.arg1 }, Numbers.Add>,
+          Match.With<
+            { x: { y: [1, 2, Match.arg0] } },
+            Strings.Prepend<"x.y[2] === ">
+          >,
+          Match.With<string, Strings.Prepend<"string: ">>,
+          Match.With<any, Functions.Constant<"default value">>
+        ]
+      >
+    >;
+
+    type res1 = MatchTest<{ nested: { value: 123 } }>;
+    //   ^?
+    type test1 = Expect<Equal<res1, "nested.value === 123">>;
+
+    type res2 = MatchTest<"world">;
+    //   ^?
+    type test2 = Expect<Equal<res2, "string: world">>;
+
+    type res3 = MatchTest<1>;
+    //   ^?
+    type test3 = Expect<Equal<res3, "default value">>;
+
+    type res4 = MatchTest<{ x: 1; y: 2 }>;
+    //   ^?
+    type test4 = Expect<Equal<res4, 3>>;
+
+    type res5 = MatchTest<{ x: { y: [1, 2, 3] } }>;
+    //   ^?
+    type test5 = Expect<Equal<res5, "x.y[2] === 3">>;
+  });
+});

--- a/test/match.test.ts
+++ b/test/match.test.ts
@@ -1,4 +1,12 @@
-import { Eval, Functions, Match, Numbers, Strings } from "../src";
+import {
+  Booleans,
+  Eval,
+  Functions,
+  Match,
+  Numbers,
+  Strings,
+  Tuples,
+} from "../src";
 import { Equal, Expect } from "../src/internals/helpers";
 
 describe("Match", () => {
@@ -98,5 +106,24 @@ describe("Match", () => {
     type res3 = MatchTest<{ x: "a"; y: "b" }>;
     //   ^?
     type test3 = Expect<Equal<res3, "ab">>;
+  });
+
+  it("Composition", () => {
+    type Transform<xs extends any[]> = Eval<
+      Tuples.Map<
+        Match<
+          [
+            Match.With<string, Strings.Replace<"0", "1">>,
+            Match.With<number, Numbers.Add<1>>,
+            Match.With<boolean, Booleans.Not>
+          ]
+        >,
+        xs
+      >
+    >;
+
+    type res1 = Transform<[1, 2, "101", true]>;
+    //    ^?
+    type test1 = Expect<Equal<res1, [2, 3, "111", false]>>;
   });
 });

--- a/test/match.test.ts
+++ b/test/match.test.ts
@@ -68,4 +68,35 @@ describe("Match", () => {
     //   ^?
     type test5 = Expect<Equal<res5, "x.y[2] === 3">>;
   });
+
+  it("should work with constrained arguments", () => {
+    type MatchTest<T> = Eval<
+      Match<
+        T,
+        [
+          Match.With<{ msg: Match.arg0<string> }, Strings.Prepend<"msg: ">>,
+          Match.With<
+            { x: Match.arg0<number>; y: Match.arg1<number> },
+            Numbers.Add
+          >,
+          Match.With<
+            { x: Match.arg0<string>; y: Match.arg1<string> },
+            Strings.Prepend
+          >
+        ]
+      >
+    >;
+
+    type res1 = MatchTest<{ msg: "hello" }>;
+    //   ^?
+    type test1 = Expect<Equal<res1, "msg: hello">>;
+
+    type res2 = MatchTest<{ x: 1; y: 2 }>;
+    //   ^?
+    type test2 = Expect<Equal<res2, 3>>;
+
+    type res3 = MatchTest<{ x: "a"; y: "b" }>;
+    //   ^?
+    type test3 = Expect<Equal<res3, "ab">>;
+  });
 });

--- a/test/match.test.ts
+++ b/test/match.test.ts
@@ -6,7 +6,7 @@ import {
   Numbers,
   Strings,
   Tuples,
-} from "../src";
+} from "../src/index";
 import { Equal, Expect } from "../src/internals/helpers";
 
 describe("Match", () => {

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -1,11 +1,9 @@
 import { Booleans } from "../src/internals/booleans/Booleans";
 import { Call, Eval, Fn, Pipe } from "../src/internals/core/Core";
 import { Strings } from "../src/internals/strings/Strings";
-import { Functions } from "../src/internals/functions/Functions";
 import { Objects } from "../src/internals/objects/Objects";
 import { Tuples } from "../src/internals/tuples/Tuples";
 import { Equal, Expect } from "../src/internals/helpers";
-import { Numbers } from "../src";
 
 describe("Objects", () => {
   it("FromEntries", () => {

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -5,6 +5,7 @@ import { Functions } from "../src/internals/functions/Functions";
 import { Objects } from "../src/internals/objects/Objects";
 import { Tuples } from "../src/internals/tuples/Tuples";
 import { Equal, Expect } from "../src/internals/helpers";
+import { Numbers } from "../src";
 
 describe("Objects", () => {
   it("FromEntries", () => {
@@ -365,22 +366,5 @@ describe("Objects", () => {
         }
       >
     >;
-  });
-
-  describe("Match", () => {
-    type MatchTest<T> = Eval<
-      Objects.Match<
-        T,
-        [
-          Objects.With<{ msg: string }, Functions.Constant<"a">>,
-          Objects.With<string, Functions.Constant<"b">>,
-          Objects.With<any, Functions.Constant<"c">>
-        ]
-      >
-    >;
-
-    type R1 = Expect<Equal<MatchTest<{ msg: "hello" }>, "a">>;
-    type R2 = Expect<Equal<MatchTest<"hello">, "b">>;
-    type R3 = Expect<Equal<MatchTest<1>, "c">>;
   });
 });


### PR DESCRIPTION
* Move `Match` to a separate module
* Put `With` in the `Match` namespace
* Add `Match.argN` patterns to destructure the input type

```ts
type MatchTest<T> = Eval<
      Match<
        T,
        [
          Match.With<
            { nested: { value: Match.arg0 } },
            Strings.Prepend<"nested.value === ">
          >,
          Match.With<{ x: Match.arg0; y: Match.arg1 }, Numbers.Add>,
          Match.With<
            { x: { y: [1, 2, Match.arg0] } },
            Strings.Prepend<"x.y[2] === ">
          >,
          Match.With<string, Strings.Prepend<"string: ">>,
          Match.With<any, Functions.Constant<"default value">>
        ]
      >
    >;

    type res1 = MatchTest<{ nested: { value: 123 } }>;
    //   ^? "nested.value === 123"
    type res2 = MatchTest<"world">;
    //   ^? "string: world"
    type res3 = MatchTest<1>;
    //   ^? "default value"
    type res4 = MatchTest<{ x: 1; y: 2 }>;
    //   ^? 3
    type res5 = MatchTest<{ x: { y: [1, 2, 3] } }>;
    //   ^? "x.y[2] === 3"


type Transform<xs extends any[]> = Eval<
  Tuples.Map<
    Match<
      [
        Match.With<string, Strings.Replace<"0", "1">>,
        Match.With<number, Numbers.Add<1>>,
        Match.With<boolean, Booleans.Not>
      ]
    >,
    xs
  >
>;

type res1 = Transform<[1, 2, "101", true]>;
//    ^? [2, 3, "111", false]
```