### PR TITLE
feat(objects): add Mutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ type res5 = Pipe<
   - [x] Concat
 - [ ] Object
   - [x] Readonly
-  - [ ] Mutable
+  - [x] Mutable
   - [x] Required
   - [x] Partial
   - [ ] ReadonlyDeep

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -283,13 +283,17 @@ export namespace Objects {
     arg3 = unset
   > = PartialApply<CreateFn, [pattern, arg0, arg1, arg2, arg3]>;
 
-  type MutableImpl<obj, keys, union = {
-    [key in keyof obj]: obj[key];
-  } & {
-    -readonly [key in Extract<keyof obj, keys>]: obj[key];
-  }> = {
+  type MutableImpl<
+    obj,
+    keys,
+    union = {
+      [key in keyof obj]: obj[key];
+    } & {
+      -readonly [key in Extract<keyof obj, keys>]: obj[key];
+    }
+  > = {
     [key in keyof union]: union[key];
-  }
+  };
 
   /**
    * Make all properties (or a specific set) of a record mutable
@@ -305,7 +309,10 @@ export namespace Objects {
    * ```
    */
   export interface Mutable extends Fn {
-    return: MutableImpl<this["arg0"], this["arg1"] extends unset ? keyof this["arg0"] : this["arg1"]>;
+    return: MutableImpl<
+      this["arg0"],
+      this["arg1"] extends unset ? keyof this["arg0"] : this["arg1"]
+    >;
   }
 
   interface RecordFn extends Fn {

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -286,13 +286,12 @@ export namespace Objects {
   type MutableImpl<
     obj,
     keys,
-    r = Std._Required<obj>,
     union = {
-      [key in keyof obj]: Std._Required<obj>[key];
+      [key in keyof obj]: obj[key];
     } & {
       -readonly [key in keyof obj as key extends keys
         ? key
-        : never]: Std._Required<obj>[key];
+        : never]: obj[key];
     }
   > = {
     [key in keyof union]: union[key];

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -289,9 +289,7 @@ export namespace Objects {
     union = {
       [key in keyof obj]: obj[key];
     } & {
-      -readonly [key in keyof obj as key extends keys
-        ? key
-        : never]: obj[key];
+      -readonly [key in keyof obj as key extends keys ? key : never]: obj[key];
     }
   > = {
     [key in keyof union]: union[key];
@@ -316,7 +314,7 @@ export namespace Objects {
    * type T0 = Call<Objects.Mutable, {readonly a: 1; readonly b: true }>; // { a:1; b: true}
    * type T1 = Eval<Objects.Mutable<{ readonly a: 1; readonly b: true }>>; // { a:1; b: true}
    * ```
-   * 
+   *
    * @example Make only a specific set of properties mutable
    * ```ts
    * type T2 = Call<Objects.Mutable<'a' | 'c'>, {readonly a: 1; readonly b: true, readonly c: 'hello' }>; // { a:1; readonly b: true, c: 'hello'}

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -283,6 +283,18 @@ export namespace Objects {
     arg3 = unset
   > = PartialApply<CreateFn, [pattern, arg0, arg1, arg2, arg3]>;
 
+  type MutableImpl<obj, keys extends keyof obj = keyof obj, union = {
+    [key in keyof obj]: obj[key];
+  } & {
+    -readonly [key in Extract<keyof obj, keys>]: obj[key];
+  }> = {
+    [key in keyof union]: union[key];
+  }
+
+  export interface Mutable extends Fn {
+    return: MutableImpl<this["arg0"], this["arg1"] extends unset ? keyof this["arg0"] : this["arg1"]>;
+  }
+
   interface RecordFn extends Fn {
     return: this["args"] extends [infer union extends string, infer value]
       ? Std._Record<union, value>

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -317,7 +317,7 @@ export namespace Objects {
    * type T1 = Eval<Objects.Mutable<{ readonly a: 1; readonly b: true }>>; // { a:1; b: true}
    * ```
    * 
-   * @example Make only a specific set of property mutable
+   * @example Make only a specific set of properties mutable
    * ```ts
    * type T2 = Call<Objects.Mutable<'a' | 'c'>, {readonly a: 1; readonly b: true, readonly c: 'hello' }>; // { a:1; readonly b: true, c: 'hello'}
    * type T3 = Eval<Objects.Mutable<'a' | 'c', {readonly a: 1; readonly b: true, readonly c: 'hello' }>>; // { a:1; readonly b: true, c: 'hello'}

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -305,15 +305,23 @@ export namespace Objects {
   }
 
   /**
-   * Make all properties of an object mutable
+   * Make all properties (or a specific set) of a record mutable
    * @description This function is used to make properties of an object mutable
    * @param obj - The object to make properties mutable
-   * @returns The object with its properties made mutable
+   * @param keys - The keys to make mutable, if not specified, all properties will be made mutable
+   * @returns The record with the specified properties made mutable
    *
-   * @example
+   * @example Make all properties mutable
    * ```ts
    * type T0 = Call<Objects.Mutable, {readonly a: 1; readonly b: true }>; // { a:1; b: true}
    * type T1 = Eval<Objects.Mutable<{ readonly a: 1; readonly b: true }>>; // { a:1; b: true}
+   * ```
+   * 
+   * @example Make only a specific set of property mutable
+   * ```ts
+   * type T2 = Call<Objects.Mutable<'a' | 'c'>, {readonly a: 1; readonly b: true, readonly c: 'hello' }>; // { a:1; readonly b: true, c: 'hello'}
+   * type T3 = Eval<Objects.Mutable<'a' | 'c', {readonly a: 1; readonly b: true, readonly c: 'hello' }>>; // { a:1; readonly b: true, c: 'hello'}
+   * type T3 = Apply<Objects.Mutable, [{readonly a: 1; readonly b: true, readonly c: 'hello' }, 'a' | 'c']> // { a:1; readonly b: true, c: 'hello'}
    * ```
    */
   export type Mutable<keys = unset, value = unset> = PartialApply<

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -295,25 +295,23 @@ export namespace Objects {
     [key in keyof union]: union[key];
   };
 
+  interface MutableFn extends Fn {
+    return: this["args"] extends [infer value] ? { -readonly [k in keyof value]: value[k] } : never;
+  }
+
   /**
-   * Make all properties (or a specific set) of a record mutable
-   * @description This function is used to make properties of a record mutable
-   * @param obj - The record to make properties mutable
-   * @param keys - The keys to make mutable, if not specified, all properties will be made mutable
-   * @returns The record with the specified properties made mutable
+   * Make all properties of an object mutable
+   * @description This function is used to make properties of an object mutable
+   * @param obj - The object to make properties mutable
+   * @returns The object with its properties made mutable
    *
    * @example
    * ```ts
-   * type T0 = Call<O.Mutable, { readonly a: 1, readonly b: 2, c: 3 }>; // { a: 1, b: 2, c: 3 }
-   * type T1 = Apply<O.Mutable, [{ readonly a: 1, readonly b: 2, readonly c: 3 }, 'a' | 'c']>; // { a: 1, readonly b: 2, c: 3 }
+   * type T0 = Call<Objects.Mutable, {readonly a: 1; readonly b: true }>; // { a:1; b: true}
+   * type T1 = Eval<Objects.Mutable<{ readonly a: 1; readonly b: true }>>; // { a:1; b: true}
    * ```
    */
-  export interface Mutable extends Fn {
-    return: MutableImpl<
-      this["arg0"],
-      this["arg1"] extends unset ? keyof this["arg0"] : this["arg1"]
-    >;
-  }
+  export type Mutable<value = unset> = PartialApply<MutableFn, [value]>;
 
   interface RecordFn extends Fn {
     return: this["args"] extends [infer union extends string, infer value]

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -283,7 +283,7 @@ export namespace Objects {
     arg3 = unset
   > = PartialApply<CreateFn, [pattern, arg0, arg1, arg2, arg3]>;
 
-  type MutableImpl<obj, keys extends keyof obj = keyof obj, union = {
+  type MutableImpl<obj, keys, union = {
     [key in keyof obj]: obj[key];
   } & {
     -readonly [key in Extract<keyof obj, keys>]: obj[key];
@@ -291,6 +291,19 @@ export namespace Objects {
     [key in keyof union]: union[key];
   }
 
+  /**
+   * Make all properties (or a specific set) of a record mutable
+   * @description This function is used to make properties of a record mutable
+   * @param obj - The record to make properties mutable
+   * @param keys - The keys to make mutable, if not specified, all properties will be made mutable
+   * @returns The record with the specified properties made mutable
+   *
+   * @example
+   * ```ts
+   * type T0 = Call<O.Mutable, { readonly a: 1, readonly b: 2, c: 3 }>; // { a: 1, b: 2, c: 3 }
+   * type T1 = Apply<O.Mutable, [{ readonly a: 1, readonly b: 2, readonly c: 3 }, 'a' | 'c']>; // { a: 1, readonly b: 2, c: 3 }
+   * ```
+   */
   export interface Mutable extends Fn {
     return: MutableImpl<this["arg0"], this["arg1"] extends unset ? keyof this["arg0"] : this["arg1"]>;
   }

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -303,11 +303,11 @@ export namespace Objects {
   }
 
   /**
-   * Make all properties (or a specific set) of a record mutable
+   * Make all properties (or a specific set) of an object mutable
    * @description This function is used to make properties of an object mutable
    * @param obj - The object to make properties mutable
    * @param keys - The keys to make mutable, if not specified, all properties will be made mutable
-   * @returns The record with the specified properties made mutable
+   * @returns The object with the specified properties made mutable
    *
    * @example Make all properties mutable
    * ```ts

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -125,7 +125,10 @@ describe("Objects", () => {
     type test5 = Expect<
       Equal<
         res5,
-        { tuple?: [string?, number?]; tuple2?: { tuple3?: [string?, number?] } }
+        {
+          tuple?: [string?, number?];
+          tuple2?: { tuple3?: [string?, number?] };
+        }
       >
     >;
 
@@ -500,15 +503,43 @@ describe("Objects", () => {
     type res1 = Call<
       //   ^?
       Objects.Mutable,
-      { readonly a: 1; readonly b: true }
+      { readonly a: 1; b: true }
     >;
     type tes1 = Expect<Equal<res1, { a: 1; b: true }>>;
 
     type res2 = Eval<
       //   ^?
-      Objects.Mutable<{ readonly a: 1; readonly b: true }>
+      Objects.Mutable<{ readonly a: 1; b: true }>
     >;
     type tes2 = Expect<Equal<res2, { a: 1; b: true }>>;
+
+    type res3 = Eval<
+      //   ^?
+      Objects.Mutable<{ readonly a?: 1; b?: true }>
+    >;
+    type tes3 = Expect<Equal<res3, { a?: 1; b?: true }>>;
+
+    // Make only certain properties mutable
+    type res4 = Call<
+      //   ^?
+      Objects.Mutable,
+      { readonly a: 1; b: true }
+    >;
+    type tes4 = Expect<Equal<res4, { a: 1; b: true }>>;
+
+    type res5 = Apply<
+      //   ^?
+      Objects.Mutable,
+      [{ a: 1; readonly b: true; readonly c: "cc" }, "a" | "c"]
+    >;
+    type tes5 = Expect<Equal<res5, { a: 1; readonly b: true; c: "cc" }>>;
+
+    type res6 = Apply<
+      //   ^?
+      Objects.Mutable,
+      [{ a?: 1; readonly b?: true; readonly c?: "cc" }, "a" | "c"]
+    >;
+    type tes6 = Expect<Equal<res6, { a?: 1; readonly b?: true; c?: "cc" }>>;
   });
 
   it("Record", () => {

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -505,11 +505,11 @@ describe("Objects", () => {
     type tes1 = Expect<Equal<res1, { a: 1; b: true }>>;
 
     type res2 = Apply<
-    //   ^?
+      //   ^?
       Objects.Mutable,
-      [{ a: 1; readonly b: true, readonly c: 'cc' },
-      "a" | "c"]>
-      type tes2 = Expect<Equal<res2, { a: 1; readonly b: true, c: 'cc' }>>;
+      [{ a: 1; readonly b: true; readonly c: "cc" }, "a" | "c"]
+    >;
+    type tes2 = Expect<Equal<res2, { a: 1; readonly b: true; c: "cc" }>>;
   });
 
   it("Record", () => {

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -527,10 +527,10 @@ describe("Objects", () => {
     >;
     type tes4 = Expect<Equal<res4, { a: 1; b: true }>>;
 
-    type res5 = Apply<
+    type res5 = Call<
       //   ^?
-      Objects.Mutable,
-      [{ a: 1; readonly b: true; readonly c: "cc" }, "a" | "c"]
+      Objects.Mutable<'a' | 'c'>,
+      { a: 1; readonly b: true; readonly c: "cc" }
     >;
     type tes5 = Expect<Equal<res5, { a: 1; readonly b: true; c: "cc" }>>;
 

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -500,16 +500,15 @@ describe("Objects", () => {
     type res1 = Call<
       //   ^?
       Objects.Mutable,
-      { readonly a: 1; b: true }
+      { readonly a: 1; readonly b: true }
     >;
     type tes1 = Expect<Equal<res1, { a: 1; b: true }>>;
 
-    type res2 = Apply<
+    type res2 = Eval<
       //   ^?
-      Objects.Mutable,
-      [{ a: 1; readonly b: true; readonly c: "cc" }, "a" | "c"]
+      Objects.Mutable<{ readonly a: 1; readonly b: true }>
     >;
-    type tes2 = Expect<Equal<res2, { a: 1; readonly b: true; c: "cc" }>>;
+    type tes2 = Expect<Equal<res2, { a: 1; b: true }>>;
   });
 
   it("Record", () => {

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -529,7 +529,7 @@ describe("Objects", () => {
 
     type res5 = Call<
       //   ^?
-      Objects.Mutable<'a' | 'c'>,
+      Objects.Mutable<"a" | "c">,
       { a: 1; readonly b: true; readonly c: "cc" }
     >;
     type tes5 = Expect<Equal<res5, { a: 1; readonly b: true; c: "cc" }>>;

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -519,7 +519,7 @@ describe("Objects", () => {
     >;
     type tes3 = Expect<Equal<res3, { a?: 1; b?: true }>>;
 
-    // Make only certain properties mutable
+    // Make a subset of properties mutable
     type res4 = Call<
       //   ^?
       Objects.Mutable,

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -496,6 +496,22 @@ describe("Objects", () => {
     });
   });
 
+  it("Mutable", () => {
+    type res1 = Call<
+      //   ^?
+      Objects.Mutable,
+      { readonly a: 1; b: true }
+    >;
+    type tes1 = Expect<Equal<res1, { a: 1; b: true }>>;
+
+    type res2 = Apply<
+    //   ^?
+      Objects.Mutable,
+      [{ a: 1; readonly b: true, readonly c: 'cc' },
+      "a" | "c"]>
+      type tes2 = Expect<Equal<res2, { a: 1; readonly b: true, c: 'cc' }>>;
+  });
+
   it("Record", () => {
     type res1 = Call<
       //   ^?

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
     "esModuleInterop": true,
     "target": "ESNext",
     "strict": true,
-    "outDir": "dist/",
-    "exactOptionalPropertyTypes": true,
+    "outDir": "dist/"
   },
   "include": ["src/"],
   "exclude": ["tests/", "dist/", "examples/"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "esModuleInterop": true,
     "target": "ESNext",
     "strict": true,
-    "outDir": "dist/"
+    "outDir": "dist/",
+    "exactOptionalPropertyTypes": true,
   },
   "include": ["src/"],
   "exclude": ["tests/", "dist/", "examples/"]


### PR DESCRIPTION
Added "Mutable" implementation for objects (loosely based on #52 - readonly implementation)
with the possibility to explicitly specify which keys should be mutable.