### PR TITLE
feat(objects): generalized args

### DIFF
--- a/src/internals/core/Core.ts
+++ b/src/internals/core/Core.ts
@@ -1,3 +1,5 @@
+import { Functions } from "../functions/Functions";
+
 declare const rawArgs: unique symbol;
 type rawArgs = typeof rawArgs;
 
@@ -34,11 +36,16 @@ export type unset = "@hotscript/unset";
  */
 export type _ = "@hotscript/placeholder";
 
-export type arg<Index extends number, Constraint = unknown> = {
-  tag: "@hotscript/arg";
-  index: Index;
-  constraint: Constraint;
-};
+export interface arg<Index extends number, Constraint = unknown> extends Fn {
+  return: this["args"][Index] extends infer arg extends Constraint
+    ? arg
+    : never;
+}
+
+export interface args<Constraint extends unknown[] = unknown[]> extends Fn {
+  return: this["args"] extends infer args extends Constraint ? args : never;
+}
+
 export type arg0<Constraint = unknown> = arg<0, Constraint>;
 export type arg1<Constraint = unknown> = arg<1, Constraint>;
 export type arg2<Constraint = unknown> = arg<2, Constraint>;

--- a/src/internals/core/Core.ts
+++ b/src/internals/core/Core.ts
@@ -1,5 +1,3 @@
-import { Functions } from "../functions/Functions";
-
 declare const rawArgs: unique symbol;
 type rawArgs = typeof rawArgs;
 

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -216,10 +216,11 @@ export namespace Objects {
       : never;
   }
 
-  type CreateImpl<pattern, args extends unknown[]> = pattern extends arg<
-    infer N extends number
-  >
-    ? args[N]
+  type CreateImpl<
+    pattern,
+    args extends unknown[]
+  > = pattern extends infer p extends Fn
+    ? Apply<p, args>
     : pattern extends Primitive
     ? pattern
     : pattern extends [any, ...any]

--- a/src/internals/tuples/Tuples.ts
+++ b/src/internals/tuples/Tuples.ts
@@ -3,6 +3,7 @@ import { Numbers as N, Numbers } from "../numbers/Numbers";
 
 import {
   Apply,
+  args,
   Call,
   Call2,
   Call3,
@@ -44,28 +45,6 @@ export namespace Tuples {
   }
 
   type IsEmptyImpl<tuple extends unknown[]> = [] extends tuple ? true : false;
-
-  interface CreateFn extends Fn {
-    return: this["args"];
-  }
-
-  /**
-   * Create a tuple from a list of arguments.
-   * @param args - The arguments to create a tuple from.
-   * @returns A tuple containing the arguments.
-   * @example
-   * ```ts
-   * type T0 = Call3<Tuples.Create, 1, 2, 3>; // [1, 2, 3]
-   * type T1 = Eval<Tuples.Create<1, 2, 3>>; // [1, 2, 3]
-   * ```
-   */
-  export type Create<
-    arg1 = unset,
-    arg2 = unset,
-    arg3 = unset,
-    arg4 = unset,
-    arg5 = unset
-  > = Functions.PartialApply<CreateFn, [arg1, arg2, arg3, arg4, arg5]>;
 
   interface IsEmptyFn extends Fn {
     return: IsEmptyImpl<Extract<this["arg0"], unknown[]>>;
@@ -686,7 +665,7 @@ export namespace Tuples {
   export type Zip<
     arr1 extends unknown[] | _ | unset = unset,
     arr2 extends unknown[] | _ | unset = unset
-  > = Functions.PartialApply<ZipWithFn<CreateFn>, [arr1, arr2]>;
+  > = Functions.PartialApply<ZipWithFn<args>, [arr1, arr2]>;
 
   /**
    * Zip two tuples together using a function.
@@ -700,8 +679,8 @@ export namespace Tuples {
    * @returns The zipped tuple.
    * @example
    * ```ts
-   * type T0 = Call2<Tuples.ZipWith<Tuples.Create>, [1, 2, 3], [10, 2, 5]>; // [[1, 10], [2, 2], [3, 5]]
-   * type T1 = Eval<Tuples.ZipWith<Tuples.Create, [1, 2, 3], [10, 2, 5]>>; // [[1, 10], [2, 2], [3, 5]]
+   * type T0 = Call2<Tuples.ZipWith<args>, [1, 2, 3], [10, 2, 5]>; // [[1, 10], [2, 2], [3, 5]]
+   * type T1 = Eval<Tuples.ZipWith<args, [1, 2, 3], [10, 2, 5]>>; // [[1, 10], [2, 2], [3, 5]]
    * type T3 = Call2<Tuples.ZipWith<N.Add>, [1, 2, 3], [10, 2, 5]>; // [11, 4, 8]
    * ```
    */

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -14,31 +14,83 @@ import {
 import { Functions } from "../src/internals/functions/Functions";
 import { Strings } from "../src/internals/strings/Strings";
 import { Objects } from "../src/internals/objects/Objects";
-import { Unions } from "../src/internals/unions/Unions";
 import { Tuples } from "../src/internals/tuples/Tuples";
 import { Equal, Expect } from "../src/internals/helpers";
 import { Match } from "../src/internals/match/Match";
+import { Numbers } from "../src/internals/numbers/Numbers";
 
 describe("Objects", () => {
-  it("Create", () => {
-    type res1 = Call<
-      //   ^?
-      Objects.Create,
-      { a: string; b: number }
-    >;
-    type tes1 = Expect<Equal<res1, { a: string; b: number }>>;
-    type res2 = Apply<
-      //   ^?
-      Objects.Create<{ a: arg0; b: arg1 }>,
-      [1, 2]
-    >;
-    type tes2 = Expect<Equal<res2, { a: 1; b: 2 }>>;
-    type res3 = Apply<
-      //   ^?
-      Objects.Create<{ a: arg0; b: [arg1, arg2]; c: { d: arg3 } }>,
-      [1, 2, 3, 4]
-    >;
-    type tes3 = Expect<Equal<res3, { a: 1; b: [2, 3]; c: { d: 4 } }>>;
+  describe("Create", () => {
+    it("should support regular objects and output them as is", () => {
+      type res1 = Call<
+        //   ^?
+        Objects.Create,
+        { a: string; b: number }
+      >;
+      type test1 = Expect<Equal<res1, { a: string; b: number }>>;
+    });
+
+    it("should interpolate arguments", () => {
+      type res2 = Apply<
+        //   ^?
+        Objects.Create<{ a: arg0; b: arg1 }>,
+        [1, 2]
+      >;
+      type test2 = Expect<Equal<res2, { a: 1; b: 2 }>>;
+
+      type res3 = Apply<
+        //   ^?
+        Objects.Create<{ a: arg0; b: [arg1, arg2]; c: { d: arg3 } }>,
+        [1, 2, 3, 4]
+      >;
+      type test3 = Expect<Equal<res3, { a: 1; b: [2, 3]; c: { d: 4 } }>>;
+    });
+
+    it("should support arbitrary functions", () => {
+      type res1 = Call<
+        //   ^?
+        Objects.Create<{
+          addition: Numbers.Add<10, _>;
+          division: Numbers.Div<_, 2>;
+          nested: [Numbers.GreaterThan<0>];
+          recursion: Functions.ComposeLeft<
+            [
+              Objects.Create<{
+                label: Strings.Prepend<"number: ">;
+                content: Strings.Append<" is the number we got!">;
+              }>,
+              Objects.Create<{
+                post: arg0;
+              }>
+            ]
+          >;
+        }>,
+        10
+      >;
+      type test2 = Expect<
+        Equal<
+          res1,
+          {
+            addition: 20;
+            division: 5;
+            nested: [true];
+            recursion: {
+              post: {
+                label: "number: 10";
+                content: "10 is the number we got!";
+              };
+            };
+          }
+        >
+      >;
+
+      type res3 = Apply<
+        //   ^?
+        Objects.Create<{ a: arg0; b: [arg1, arg2]; c: { d: arg3 } }>,
+        [1, 2, 3, 4]
+      >;
+      type test3 = Expect<Equal<res3, { a: 1; b: [2, 3]; c: { d: 4 } }>>;
+    });
   });
 
   it("FromEntries", () => {
@@ -47,7 +99,7 @@ describe("Objects", () => {
       Objects.FromEntries,
       ["a", string] | ["b", number]
     >;
-    type tes1 = Expect<Equal<res1, { a: string; b: number }>>;
+    type test1 = Expect<Equal<res1, { a: string; b: number }>>;
   });
 
   it("Entries", () => {
@@ -56,7 +108,7 @@ describe("Objects", () => {
       Objects.Entries,
       { a: string; b: number }
     >;
-    type tes1 = Expect<Equal<res1, ["a", string] | ["b", number]>>;
+    type test1 = Expect<Equal<res1, ["a", string] | ["b", number]>>;
   });
 
   it("Entries >> FromEntries identity", () => {
@@ -66,7 +118,7 @@ describe("Objects", () => {
     >;
     //   ^?
 
-    type tes1 = Expect<Equal<res1, { a: string; b: number }>>;
+    type test1 = Expect<Equal<res1, { a: string; b: number }>>;
   });
 
   it("MapValues", () => {
@@ -75,7 +127,7 @@ describe("Objects", () => {
       Objects.MapValues<Strings.ToString>,
       { a: 1; b: true }
     >;
-    type tes1 = Expect<Equal<res1, { a: "1"; b: "true" }>>;
+    type test1 = Expect<Equal<res1, { a: "1"; b: "true" }>>;
   });
 
   it("MapKeys", () => {
@@ -84,7 +136,7 @@ describe("Objects", () => {
       Objects.MapKeys<Strings.Prepend<"get_">>,
       { a: 1; b: true }
     >;
-    type tes1 = Expect<Equal<res1, { get_a: 1; get_b: true }>>;
+    type test1 = Expect<Equal<res1, { get_a: 1; get_b: true }>>;
   });
 
   it("Pick", () => {
@@ -93,7 +145,7 @@ describe("Objects", () => {
       Objects.Pick<"a">,
       { a: 1; b: true }
     >;
-    type tes1 = Expect<Equal<res1, { a: 1 }>>;
+    type test1 = Expect<Equal<res1, { a: 1 }>>;
   });
 
   it("Omit", () => {
@@ -102,7 +154,7 @@ describe("Objects", () => {
       Objects.Omit<"a">,
       { a: 1; b: true }
     >;
-    type tes1 = Expect<Equal<res1, { b: true }>>;
+    type test1 = Expect<Equal<res1, { b: true }>>;
   });
 
   it("PickBy", () => {
@@ -111,7 +163,7 @@ describe("Objects", () => {
       Objects.PickBy<Booleans.Extends<1>>,
       { a: 1; b: true; c: 1 }
     >;
-    type tes1 = Expect<Equal<res1, { a: 1; c: 1 }>>;
+    type test1 = Expect<Equal<res1, { a: 1; c: 1 }>>;
   });
 
   it("OmitBy", () => {
@@ -120,7 +172,7 @@ describe("Objects", () => {
       Objects.OmitBy<Booleans.Extends<1>>,
       { a: 1; b: true; c: 1 }
     >;
-    type tes1 = Expect<Equal<res1, { b: true }>>;
+    type test1 = Expect<Equal<res1, { b: true }>>;
   });
 
   describe("Assign", () => {
@@ -130,14 +182,14 @@ describe("Objects", () => {
         Tuples.Reduce<Objects.Assign, {}>,
         [{ a: 1 }, { b: true }, { c: 1 }]
       >;
-      type tes1 = Expect<Equal<res1, { a: 1; b: true; c: 1 }>>;
+      type test1 = Expect<Equal<res1, { a: 1; b: true; c: 1 }>>;
 
       type res2 = Call<
         //   ^?
         Tuples.Reduce<Objects.Assign, {}>,
         [{ a: 2 }, { b: true }, { c: 2 }]
       >;
-      type tes2 = Expect<Equal<res2, { a: 2; b: true; c: 2 }>>;
+      type test2 = Expect<Equal<res2, { a: 2; b: true; c: 2 }>>;
     });
 
     it("can be called with one pre-filled argument", () => {

--- a/test/tuples.test.ts
+++ b/test/tuples.test.ts
@@ -1,6 +1,9 @@
+import { Objects } from "../src";
 import { Booleans } from "../src/internals/booleans/Booleans";
 import {
   Apply,
+  arg0,
+  args,
   Call,
   Call2,
   Eval,
@@ -14,16 +17,6 @@ import { Strings } from "../src/internals/strings/Strings";
 import { Tuples } from "../src/internals/tuples/Tuples";
 
 describe("Tuples", () => {
-  it("Create", () => {
-    type res1 = Apply<Tuples.Create, [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]>;
-    //   ^?
-    type tes1 = Expect<Equal<res1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]>>;
-
-    type res2 = Eval<Tuples.Create<1, 2, 3, 4, 5>>;
-    //   ^?
-    type tes2 = Expect<Equal<res2, [1, 2, 3, 4, 5]>>;
-  });
-
   it("Head", () => {
     type res1 = Call<Tuples.Head, [1, 2, 3]>;
     //   ^?


### PR DESCRIPTION
## Motivation

The idea is to turn the `args, arg0, arg{n}` keywords into functions. This has 2 benefits:

1. This make them usable in more context, and make them composable with other functions:

```ts
type res1 = Eval<
   Tuples.Reduce<args, [], [1, 2, 3]> 
>
// => [[[[], 1], 2], 3]

type res2 = Eval<
   Tuples.ZipWith<args, ['a', 'b', 'c'], [1, 2, 3]> 
>
// => [['a', 1], ['b', 2], ['c', 3]]
```

2. It means we can generalize Objects.Create to work with any nested function:

```ts
type res1 = Call<
        //   ^?
        Objects.Create<{
          addition: Numbers.Add<10, _>;
          division: Numbers.Div<_, 2>;
          nested: [Numbers.GreaterThan<0>];
          recursion: Functions.ComposeLeft<
            [
              Objects.Create<{
                label: Strings.Prepend<"number: ">;
                content: Strings.Append<" is the number we got!">;
              }>,
              Objects.Create<{
                post: arg0;
              }>
            ]
          >;
        }>,
        10
      >;
      type test2 = Expect<
        Equal<
          res1,
          {
            addition: 20;
            division: 5;
            nested: [true];
            recursion: {
              post: {
                label: "number: 10";
                content: "10 is the number we got!";
              };
            };
          }
        >
      >;
```
