### PR TITLE
feat(objects): ReadonlyDeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ type T = {
   - [ ] Mutable
   - [x] Required
   - [x] Partial
-  - [ ] ReadonlyDeep
+  - [x] ReadonlyDeep
   - [ ] MutableDeep
   - [ ] RequiredDeep
   - [x] PartialDeep

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -204,6 +204,23 @@ export namespace Objects {
   }
 
   /**
+   * Makes all levels of an object read-only
+   * @description This function is used to make all levels of an object read-only
+   * @param obj - The object to make levels read-only
+   * @returns The object with its levels made read-only
+   * @example
+   * ```ts
+   * type T0 = Call<Objects.ReadonlyDeep, {a: 1; b: true }>; // { readonly a:1; readonly b: true}
+   * type T1 = Call<Objects.ReadonlyDeep, {a: 1; b: { c: true } }>; // { readonly a:1; readonly b: { readonly c: true } }
+   */
+
+  export type ReadonlyDeep<obj = unset> = PartialApply<ReadonlyDeepFn, [obj]>;
+
+  interface ReadonlyDeepFn extends Fn {
+    return: this["args"] extends [infer obj] ? Impl.ReadonlyDeep<obj> : never;
+  }
+
+  /**
    * Makes all levels of an object optional
    * @description This function is used to make all levels of an object optional
    * @param obj - The object to make levels optional

--- a/src/internals/objects/impl/objects.ts
+++ b/src/internals/objects/impl/objects.ts
@@ -79,6 +79,10 @@ type RecursiveGet<Obj, pathList> = Obj extends any
     : Obj
   : never;
 
+export type ReadonlyDeep<T> = T extends object
+  ? { readonly [P in keyof T]: ReadonlyDeep<T[P]> }
+  : T;
+
 export type PartialDeep<T> = T extends object
   ? { [P in keyof T]?: PartialDeep<T[P]> }
   : T;

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -95,6 +95,65 @@ describe("Objects", () => {
     });
   });
 
+  it("ReadonlyDeep", () => {
+    type res0 = Call<Objects.ReadonlyDeep, { a: 1; b: 2 }>;
+    //    ^?
+    type test0 = Expect<Equal<res0, { readonly a: 1; readonly b: 2 }>>;
+
+    type res1 = Call<Objects.ReadonlyDeep, { a: 1; b: { c: 2 } }>;
+    //    ^?
+    type test1 = Expect<
+      Equal<res1, { readonly a: 1; readonly b: { readonly c: 2 } }>
+    >;
+
+    type res2 = Call<Objects.ReadonlyDeep, { a: 1; b: { c: 2; d: { e: 3 } } }>;
+    //    ^?
+    type test2 = Expect<
+      Equal<
+        res2,
+        {
+          readonly a: 1;
+          readonly b: { readonly c: 2; readonly d: { readonly e: 3 } };
+        }
+      >
+    >;
+
+    type tuple = [string, number];
+    type res3 = Call<Objects.ReadonlyDeep, tuple>;
+    //    ^?
+    type test3 = Expect<Equal<res3, readonly [string, number]>>;
+
+    type res4 = Call<Objects.ReadonlyDeep, [string, tuple]>;
+    //    ^?
+    type test4 = Expect<
+      Equal<res4, readonly [string, readonly [string, number]]>
+    >;
+
+    type res5 = Call<
+      Objects.ReadonlyDeep,
+      { tuple: tuple; tuple2: { tuple3: tuple } }
+    >;
+    //    ^?
+    type test5 = Expect<
+      Equal<
+        res5,
+        {
+          readonly tuple: readonly [string, number];
+          readonly tuple2: { readonly tuple3: readonly [string, number] };
+        }
+      >
+    >;
+
+    type res6 = Call<Objects.ReadonlyDeep, { tuple: [string, tuple] }>;
+    //    ^?
+    type test6 = Expect<
+      Equal<
+        res6,
+        { readonly tuple: readonly [string, readonly [string, number]] }
+      >
+    >;
+  });
+
   it("PartialDeep", () => {
     type res0 = Call<Objects.PartialDeep, { a: 1; b: 2 }>;
     //    ^?


### PR DESCRIPTION
Makes all levels of a type readonly

 ```ts
   type T0 = Call<Objects.ReadonlyDeep, {a: 1; b: true }>; // { readonly a:1; readonly b: true}
   type T1 = Call<Objects.ReadonlyDeep, {a: 1; b: { c: true } }>; // { readonly a:1; readonly b: { readonly c: true } }
```

![image](https://user-images.githubusercontent.com/44379716/221410672-5aa266e6-bc46-4bc7-b6e9-34d26af040f6.png)
