### PR TITLE
refact: PartialDeep alignment for different structures

### DIFF
--- a/src/internals/helpers.ts
+++ b/src/internals/helpers.ts
@@ -137,15 +137,6 @@ export type KebabCase<
   ? str
   : output;
 
-// https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
-export type IsAny<type> = 0 extends 1 & type ? true : false;
-
-export type IsUnknown<type> = IsAny<type> extends true
-  ? false
-  : unknown extends type
-  ? true
-  : false;
-
 export type IsTuple<a extends readonly any[]> = a extends
   | readonly []
   | readonly [any, ...any]

--- a/src/internals/helpers.ts
+++ b/src/internals/helpers.ts
@@ -137,6 +137,15 @@ export type KebabCase<
   ? str
   : output;
 
+// https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
+export type IsAny<type> = 0 extends 1 & type ? true : false;
+
+export type IsUnknown<type> = IsAny<type> extends true
+  ? false
+  : unknown extends type
+  ? true
+  : false;
+
 export type IsTuple<a extends readonly any[]> = a extends
   | readonly []
   | readonly [any, ...any]

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -339,7 +339,7 @@ export namespace Objects {
    * @returns The object with its properties made readonly
    * @example
    * ```ts
-   * type T0 = Call<Objects.Readonly, {a: 1; b: true }>; // { readonly a:1; readonly b: true}
+   * type T0 = Call<Objects.Readonly, { a: 1; b: true }>; // { readonly a:1; readonly b: true}
    * type T1 = Eval<Objects.Readonly<{ a: 1; b: true }>>; // { readonly a:1; readonly b: true}
    * ```
    */
@@ -356,7 +356,7 @@ export namespace Objects {
    * @returns The object with its properties made required
    * @example
    * ```ts
-   * type T0 = Call<Objects.Required, {a?: 1; b?: true }>; // { a:1; b: true}
+   * type T0 = Call<Objects.Required, { a?: 1; b?: true }>; // { a:1; b: true}
    * type T1 = Eval<Objects.Required<{ a?: 1; b?: true }>>; // { a:1; b: true}
    * ```
    */
@@ -373,7 +373,7 @@ export namespace Objects {
    * @returns The object with its properties made optional
    * @example
    * ```ts
-   * type T0 = Call<Objects.Partial, {a: 1; b: true }>; // { a?:1; b?: true}
+   * type T0 = Call<Objects.Partial, { a: 1; b: true }>; // { a?:1; b?: true}
    * type T1 = Eval<Objects.Partial<{ a: 1; b: true }>>; // { a?:1; b?: true}
    * ```
    */
@@ -384,6 +384,23 @@ export namespace Objects {
   }
 
   /**
+   * Make all properties of an object mutable
+   * @param value - The object to make properties mutable
+   * @returns The object with its properties made mutable
+   * @example
+   * ```ts
+   * type T0 = Call<Objects.Mutable, { readonly a: 1; readonly b: true }>; // { a:1; b: true }
+   * ```
+   */
+  export type Mutable<obj = unset> = PartialApply<MutableFn, [obj]>;
+
+  interface MutableFn extends Fn {
+    return: this["args"] extends [infer obj, ...any]
+      ? { -readonly [key in keyof obj]: obj[key] }
+      : never;
+  }
+
+  /**
    * Makes all levels of an object optional
    * @description This function is used to make all levels of an object optional
    * @param obj - The object to make levels optional
@@ -391,11 +408,13 @@ export namespace Objects {
    *
    * @example
    * ```ts
-   * type T0 = Call<Objects.PartialDeep, {a: 1; b: true }>; // { a?:1; b?: true}
-   * type T1 = Call<Objects.PartialDeep, {a: 1; b: { c: true } }>; // { a?:1; b?: { c?: true } }
-   * type T2 = Call<Objects.PartialDeep, {a: 1; b: { c: true, d: { e: false } } }>; // { a?:1; b?: { c?: true, d?: { e?: false } } }
+   * type T0 = Call<Objects.PartialDeep, { a: 1; b: true }>;
+   * //   ^? { a?:1; b?: true}
+   * type T1 = Call<Objects.PartialDeep, { a: 1; b: { c: true } }>;
+   * //   ^? { a?:1; b?: { c?: true } }
+   * type T2 = Call<Objects.PartialDeep, { a: 1; b: { c: true, d: { e: false } } }>;
+   * //   ^? { a?:1; b?: { c?: true, d?: { e?: false } } }
    */
-
   export type PartialDeep<obj = unset> = PartialApply<PartialDeepFn, [obj]>;
 
   interface PartialDeepFn extends Fn {
@@ -404,6 +423,21 @@ export namespace Objects {
       : never;
   }
 
+  /**
+   * Makes all levels of an object required
+   * @description This function is used to make all levels of an object required
+   * @param obj - The object to make levels required
+   * @returns The object with its levels made required
+   *
+   * @example
+   * ```ts
+   * type T0 = Call<Objects.RequiredDeep, { a?:1; b?: true }>;
+   * //   ^? { a: 1; b: true }
+   * type T1 = Call<Objects.RequiredDeep, { a?:1; b?: { c?: true } }>;
+   * //   ^? { a: 1; b: { c: true } }
+   * type T2 = Call<Objects.RequiredDeep, { a?:1; b?: { c?: true, d?: { e?: false } } }>;
+   * //   ^? { a: 1; b: { c: true, d: { e: false } } }
+   */
   export type RequiredDeep<obj = unset> = PartialApply<RequiredDeepFn, [obj]>;
 
   interface RequiredDeepFn extends Fn {
@@ -412,6 +446,21 @@ export namespace Objects {
       : never;
   }
 
+  /**
+   * Makes all levels of an object readonly
+   * @description This function is used to make all levels of an object readonly
+   * @param obj - The object to make levels readonly
+   * @returns The object with its levels made readonly
+   *
+   * @example
+   * ```ts
+   * type T0 = Call<Objects.ReadonlyDeep, { a:1; b: true }>;
+   * //   ^? { readonly a: 1; readonly b: true }
+   * type T1 = Call<Objects.ReadonlyDeep, { a:1; b: { c: true } }>;
+   * //   ^? { readonly a: 1; readonly b: { readonly c: true } }
+   * type T2 = Call<Objects.ReadonlyDeep, { a:1; b: { c: true, d: { e: false } } }>;
+   * //   ^? { readonly a: 1; readonly b: { readonly c: true, d: { readonly e: false } } }
+   */
   export type ReadonlyDeep<obj = unset> = PartialApply<ReadonlyDeepFn, [obj]>;
 
   interface ReadonlyDeepFn extends Fn {
@@ -420,19 +469,26 @@ export namespace Objects {
       : never;
   }
 
+  /**
+   * Makes all levels of an object mutable
+   * @description This function is used to make all levels of an object mutable
+   * @param obj - The object to make levels mutable
+   * @returns The object with its levels made mutable
+   *
+   * @example
+   * ```ts
+   * type T0 = Call<Objects.MutableDeep, { readonly a: 1; readonly b: true }>;
+   * //   ^? { a:1; b: true }
+   * type T1 = Call<Objects.MutableDeep, { readonly a: 1; readonly b: { readonly c: true } }>;
+   * //   ^? { a:1; b: { c: true } }
+   * type T2 = Call<Objects.MutableDeep, { readonly a: 1; readonly b: { readonly c: true, d: { readonly e: false } } }>;
+   * //   ^? { a:1; b: { c: true, d: { e: false } } }
+   */
   export type MutableDeep<obj = unset> = PartialApply<MutableDeepFn, [obj]>;
 
   interface MutableDeepFn extends Fn {
     return: this["args"] extends [infer obj]
       ? Impl.TransformObjectDeep<MutableFn, obj>
-      : never;
-  }
-
-  export type Mutable<obj = unset> = PartialApply<MutableFn, [obj]>;
-
-  interface MutableFn extends Fn {
-    return: this["args"] extends [infer obj, ...any]
-      ? { -readonly [key in keyof obj]: obj[key] }
       : never;
   }
 

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -384,18 +384,20 @@ export namespace Objects {
   }
 
   /**
-   * Makes all levels of an object optional
-   * @description This function is used to make all levels of an object optional
-   * @param obj - The object to make levels optional
-   * @returns The object with its levels made optional
-   *
+   * Makes all levels of an object partial
+   * @description This function is used to make all levels of an object partial
+   * @param obj - The object to make levels partial
+   * @returns The object with its levels made partial
    * @example
    * ```ts
-   * type T0 = Call<Objects.PartialDeep, {a: 1; b: true }>; // { a?:1; b?: true}
-   * type T1 = Call<Objects.PartialDeep, {a: 1; b: { c: true } }>; // { a?:1; b?: { c?: true } }
-   * type T2 = Call<Objects.PartialDeep, {a: 1; b: { c: true, d: { e: false } } }>; // { a?:1; b?: { c?: true, d?: { e?: false } } }
+   * type T0 = Call<Objects.PartialDeep, {a: 1; b: true}>;
+   * //   ^? {a?: 1; b?: true}
+   * type T1 = Call<Objects.PartialDeep, {a: 1; b: {c: true}}>;
+   * //   ^? {a?: 1; b?: {c?: true}}
+   * type T2 = Call<Objects.PartialDeep, {a: 1; b: {c: true, d: {e: false}}}>;
+   * //   ^? {a?: 1; b?: {c?: true, d?: {e?: false}}}
+   * ```
    */
-
   export type PartialDeep<obj = unset> = PartialApply<PartialDeepFn, [obj]>;
 
   interface PartialDeepFn extends Fn {

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -420,6 +420,22 @@ export namespace Objects {
       : never;
   }
 
+  export type MutableDeep<obj = unset> = PartialApply<MutableDeepFn, [obj]>;
+
+  interface MutableDeepFn extends Fn {
+    return: this["args"] extends [infer obj]
+      ? Impl.TransformObjectDeep<MutableFn, obj>
+      : never;
+  }
+
+  export type Mutable<obj = unset> = PartialApply<MutableFn, [obj]>;
+
+  interface MutableFn extends Fn {
+    return: this["args"] extends [infer obj, ...any]
+      ? { -readonly [key in keyof obj]: obj[key] }
+      : never;
+  }
+
   /**
    * Get a value within an object or a tuple type.
    * @description This function takes an object, a path to one of its properties,

--- a/src/internals/objects/Objects.ts
+++ b/src/internals/objects/Objects.ts
@@ -384,24 +384,40 @@ export namespace Objects {
   }
 
   /**
-   * Makes all levels of an object partial
-   * @description This function is used to make all levels of an object partial
-   * @param obj - The object to make levels partial
-   * @returns The object with its levels made partial
+   * Makes all levels of an object optional
+   * @description This function is used to make all levels of an object optional
+   * @param obj - The object to make levels optional
+   * @returns The object with its levels made optional
+   *
    * @example
    * ```ts
-   * type T0 = Call<Objects.PartialDeep, {a: 1; b: true}>;
-   * //   ^? {a?: 1; b?: true}
-   * type T1 = Call<Objects.PartialDeep, {a: 1; b: {c: true}}>;
-   * //   ^? {a?: 1; b?: {c?: true}}
-   * type T2 = Call<Objects.PartialDeep, {a: 1; b: {c: true, d: {e: false}}}>;
-   * //   ^? {a?: 1; b?: {c?: true, d?: {e?: false}}}
-   * ```
+   * type T0 = Call<Objects.PartialDeep, {a: 1; b: true }>; // { a?:1; b?: true}
+   * type T1 = Call<Objects.PartialDeep, {a: 1; b: { c: true } }>; // { a?:1; b?: { c?: true } }
+   * type T2 = Call<Objects.PartialDeep, {a: 1; b: { c: true, d: { e: false } } }>; // { a?:1; b?: { c?: true, d?: { e?: false } } }
    */
+
   export type PartialDeep<obj = unset> = PartialApply<PartialDeepFn, [obj]>;
 
   interface PartialDeepFn extends Fn {
-    return: this["args"] extends [infer obj] ? Impl.PartialDeep<obj> : never;
+    return: this["args"] extends [infer obj]
+      ? Impl.TransformObjectDeep<PartialFn, obj>
+      : never;
+  }
+
+  export type RequiredDeep<obj = unset> = PartialApply<RequiredDeepFn, [obj]>;
+
+  interface RequiredDeepFn extends Fn {
+    return: this["args"] extends [infer obj]
+      ? Impl.TransformObjectDeep<RequiredFn, obj>
+      : never;
+  }
+
+  export type ReadonlyDeep<obj = unset> = PartialApply<ReadonlyDeepFn, [obj]>;
+
+  interface ReadonlyDeepFn extends Fn {
+    return: this["args"] extends [infer obj]
+      ? Impl.TransformObjectDeep<ReadonlyFn, obj>
+      : never;
   }
 
   /**

--- a/src/internals/objects/impl/objects.ts
+++ b/src/internals/objects/impl/objects.ts
@@ -3,7 +3,6 @@ import { Strings } from "../../strings/Strings";
 import {
   Equal,
   IsTuple,
-  IsUnknown,
   Prettify,
   Primitive,
   UnionToIntersection,
@@ -92,7 +91,7 @@ export type TransformObjectDeep<fn extends Fn, type> = type extends
   ? Promise<TransformObjectDeep<fn, value>>
   : type extends object
   ? Call<fn, { [Key in keyof type]: TransformObjectDeep<fn, type[Key]> }>
-  : IsUnknown<type> extends true
+  : Equal<type, unknown> extends true
   ? unknown
   : Partial<type>;
 

--- a/src/internals/objects/impl/objects.ts
+++ b/src/internals/objects/impl/objects.ts
@@ -58,9 +58,9 @@ type RecursiveGet<Obj, pathList> = Obj extends any
     : Obj
   : never;
 
-export type PartialDeep<T> = T extends object
-  ? { [P in keyof T]?: PartialDeep<T[P]> }
-  : T;
+export type PartialDeep<Type> = Type extends object
+  ? { [Key in keyof Type]?: PartialDeep<Type[Key]> }
+  : Partial<Type>;
 
 export type Update<obj, path, fnOrValue> = RecursiveUpdate<
   obj,

--- a/src/internals/objects/impl/objects.ts
+++ b/src/internals/objects/impl/objects.ts
@@ -65,31 +65,36 @@ type RecursiveGet<Obj, pathList> = Obj extends any
     : Obj
   : never;
 
-export type PartialDeep<Type> = Type extends Function | Date
-  ? Type
-  : Type extends Map<infer Keys, infer Values>
-  ? Map<PartialDeep<Keys>, PartialDeep<Values>>
-  : Type extends ReadonlyMap<infer Keys, infer Values>
-  ? ReadonlyMap<PartialDeep<Keys>, PartialDeep<Values>>
-  : Type extends WeakMap<infer Keys, infer Values>
-  ? WeakMap<PartialDeep<Keys>, PartialDeep<Values>>
-  : Type extends Set<infer Values>
-  ? Set<PartialDeep<Values>>
-  : Type extends ReadonlySet<infer Values>
-  ? ReadonlySet<PartialDeep<Values>>
-  : Type extends WeakSet<infer Values>
-  ? WeakSet<PartialDeep<Values>>
-  : Type extends Array<infer Values>
-  ? IsTuple<Type> extends true
-    ? { [Key in keyof Type]?: PartialDeep<Type[Key]> }
-    : Array<PartialDeep<Values> | undefined>
-  : Type extends Promise<infer Value>
-  ? Promise<PartialDeep<Value>>
-  : Type extends object
-  ? { [Key in keyof Type]?: PartialDeep<Type[Key]> }
-  : IsUnknown<Type> extends true
+export type TransformObjectDeep<fn extends Fn, type> = type extends
+  | Function
+  | Date
+  ? type
+  : type extends Map<infer keys, infer values>
+  ? Map<TransformObjectDeep<fn, keys>, TransformObjectDeep<fn, values>>
+  : type extends ReadonlyMap<infer keys, infer values>
+  ? ReadonlyMap<TransformObjectDeep<fn, keys>, TransformObjectDeep<fn, values>>
+  : type extends WeakMap<infer keys, infer values>
+  ? WeakMap<
+      Extract<TransformObjectDeep<fn, keys>, object>,
+      TransformObjectDeep<fn, values>
+    >
+  : type extends Set<infer values>
+  ? Set<TransformObjectDeep<fn, values>>
+  : type extends ReadonlySet<infer values>
+  ? ReadonlySet<TransformObjectDeep<fn, values>>
+  : type extends WeakSet<infer values>
+  ? WeakSet<Extract<TransformObjectDeep<fn, values>, object>>
+  : type extends Array<infer values>
+  ? IsTuple<type> extends true
+    ? Call<fn, { [Key in keyof type]: TransformObjectDeep<fn, type[Key]> }>
+    : Array<TransformObjectDeep<fn, values> | undefined>
+  : type extends Promise<infer value>
+  ? Promise<TransformObjectDeep<fn, value>>
+  : type extends object
+  ? Call<fn, { [Key in keyof type]: TransformObjectDeep<fn, type[Key]> }>
+  : IsUnknown<type> extends true
   ? unknown
-  : Partial<Type>;
+  : Partial<type>;
 
 export type Update<obj, path, fnOrValue> = RecursiveUpdate<
   obj,

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -260,216 +260,170 @@ describe("Objects", () => {
     type test1 = Expect<Equal<res1, { b: true }>>;
   });
 
-  it("PartialDeep", () => {
-    // interface ExtendedFunction extends Function {
-    //   args: 0;
-    // }
+  describe("PartialDeep", () => {
+    it("primitives", () => {
+      type res0 = Call<Objects.PartialDeep, number>;
+      type test0 = Expect<Equal<res0, number>>;
 
-    // interface ExtendedDate extends Date {
-    //   today(): number;
-    // }
+      type res1 = Call<Objects.PartialDeep, string>;
+      type test1 = Expect<Equal<res1, string>>;
 
-    // interface ExtendedError extends Error {
-    //   code: string;
-    // }
+      type res2 = Call<Objects.PartialDeep, boolean>;
+      type test2 = Expect<Equal<res2, boolean>>;
 
-    // interface ExtendedRegExp extends RegExp {
-    //   caseSensitive: true;
-    // }
+      type res3 = Call<Objects.PartialDeep, bigint>;
+      type test3 = Expect<Equal<res3, bigint>>;
 
-    type ComplexNestedRequired = {
-      simple: number;
-      nested: {
-        date: Date;
-        func: () => string;
-        array: { bar: number }[];
-        tuple: [string, number, { good: boolean }];
-        set: Set<{ name: string }>;
-        map: Map<
-          string,
-          {
-            name: string;
-          }
-        >;
-        promise: Promise<{ foo: string; bar: number }>;
-      };
-    };
+      type res4 = Call<Objects.PartialDeep, symbol>;
+      type test4 = Expect<Equal<res4, symbol>>;
 
-    type ComplexNestedPartial = {
-      simple?: number;
-      nested?: {
-        date?: Date;
-        func?: () => string;
-        array?: ({ bar?: number } | undefined)[];
-        set?: Set<{ name?: string }>;
-        tuple?: [string?, number?, { good?: boolean }?];
-        map?: Map<
-          string,
-          {
-            name?: string;
-          }
-        >;
-        promise?: Promise<{ foo?: string; bar?: number }>;
-      };
-    };
+      type res5 = Call<Objects.PartialDeep, undefined>;
+      type test5 = Expect<Equal<res5, undefined>>;
 
-    type cases = [
-      Expect<Equal<Call<Objects.PartialDeep, number>, number>>,
-      Expect<Equal<Call<Objects.PartialDeep, string>, string>>,
-      Expect<Equal<Call<Objects.PartialDeep, boolean>, boolean>>,
-      Expect<Equal<Call<Objects.PartialDeep, bigint>, bigint>>,
-      Expect<Equal<Call<Objects.PartialDeep, symbol>, symbol>>,
-      Expect<Equal<Call<Objects.PartialDeep, undefined>, undefined>>,
-      Expect<Equal<Call<Objects.PartialDeep, null>, null>>,
-      // Expect<Equal<Call<Objects.PartialDeep, Function>, Function>>,
-      // Expect<
-      //   Equal<
-      //     Call<Objects.PartialDeep, ExtendedFunction>,
-      //     Function & { args: 0 }
-      //   >
-      // >,
-      // Expect<Equal<Call<Objects.PartialDeep, Date>, Date>>,
-      // Expect<
-      //   Equal<
-      //     Call<Objects.PartialDeep, ExtendedDate>,
-      //     Date & { today(): number }
-      //   >
-      // >,
-      // Expect<Equal<Call<Objects.PartialDeep, Error>, Error>>,
-      // Expect<
-      //   Equal<
-      //     Call<Objects.PartialDeep, ExtendedError>,
-      //     Error & { code: string }
-      //   >
-      // >,
-      // Expect<Equal<Call<Objects.PartialDeep, RegExp>, RegExp>>,
-      // Expect<
-      //   Equal<
-      //     Call<Objects.PartialDeep, ExtendedRegExp>,
-      //     RegExp & { caseSensitive: true }
-      //   >
-      // >,
-      Expect<
+      type res6 = Call<Objects.PartialDeep, null>;
+      type test6 = Expect<Equal<res6, null>>;
+
+      type res7 = Call<Objects.PartialDeep, Function>;
+      type test7 = Expect<Equal<res7, Function>>;
+    });
+
+    it("Map & Set", () => {
+      type res0 = Call<Objects.PartialDeep, Map<string, boolean>>;
+      type test0 = Expect<Equal<res0, Map<string, boolean>>>;
+
+      type res1 = Call<Objects.PartialDeep, Map<string, { a: number }>>;
+      type test1 = Expect<Equal<res1, Map<string, { a?: number }>>>;
+
+      type res2 = Call<Objects.PartialDeep, ReadonlyMap<string, boolean>>;
+      type test2 = Expect<Equal<res2, ReadonlyMap<string, boolean>>>;
+
+      type res3 = Call<
+        Objects.PartialDeep,
+        ReadonlyMap<string, { checked: boolean }>
+      >;
+      type test3 = Expect<
+        Equal<res3, ReadonlyMap<string, { checked?: boolean }>>
+      >;
+
+      type res4 = Call<Objects.PartialDeep, WeakMap<{ key: string }, boolean>>;
+      type test4 = Expect<Equal<res4, WeakMap<{ key?: string }, boolean>>>;
+
+      type res5 = Call<
+        Objects.PartialDeep,
+        WeakMap<{ key: string }, { value: boolean }>
+      >;
+      type test5 = Expect<
+        Equal<res5, WeakMap<{ key?: string }, { value?: boolean }>>
+      >;
+
+      type res6 = Call<Objects.PartialDeep, Set<string>>;
+      type test6 = Expect<Equal<res6, Set<string>>>;
+
+      type res7 = Call<Objects.PartialDeep, Set<number[]>>;
+      type test7 = Expect<Equal<res7, Set<(number | undefined)[]>>>;
+
+      type res8 = Call<Objects.PartialDeep, ReadonlySet<string>>;
+      type test8 = Expect<Equal<res8, ReadonlySet<string>>>;
+    });
+
+    it("Objects and Arrays", () => {
+      type res1 = Call<Objects.PartialDeep, []>;
+      type test1 = Expect<Equal<res1, []>>;
+
+      type res2 = Call<Objects.PartialDeep, never[]>;
+      type test2 = Expect<Equal<res2, undefined[]>>;
+
+      type res3 = Call<Objects.PartialDeep, [1, 2, 3]>;
+      type test3 = Expect<
+        Equal<res3, [(1 | undefined)?, (2 | undefined)?, (3 | undefined)?]>
+      >;
+
+      type res4 = Call<Objects.PartialDeep, readonly number[]>;
+      type test4 = Expect<Equal<res4, readonly (number | undefined)[]>>;
+
+      type res5 = Call<Objects.PartialDeep, number[]>;
+      type test5 = Expect<Equal<res5, (number | undefined)[]>>;
+
+      type res6 = Call<Objects.PartialDeep, Array<number>>;
+      type test6 = Expect<Equal<res6, Array<number | undefined>>>;
+
+      type res7 = Call<
+        Objects.PartialDeep,
+        { readonly obj: unknown; readonly arr: readonly unknown[] }
+      >;
+      type test7 = Expect<
         Equal<
-          Call<Objects.PartialDeep, Map<string, boolean>>,
-          Map<string, boolean>
-        >
-      >,
-      Expect<
-        Equal<
-          Call<Objects.PartialDeep, Map<string, { a: number }>>,
-          Map<string, { a?: number }>
-        >
-      >,
-      Expect<
-        Equal<
-          Call<Objects.PartialDeep, ReadonlyMap<string, boolean>>,
-          ReadonlyMap<string, boolean>
-        >
-      >,
-      Expect<
-        Equal<
-          Call<Objects.PartialDeep, ReadonlyMap<string, { checked: boolean }>>,
-          ReadonlyMap<string, { checked?: boolean }>
-        >
-      >,
-      Expect<
-        Equal<
-          Call<Objects.PartialDeep, WeakMap<{ key: string }, boolean>>,
-          WeakMap<{ key?: string }, boolean>
-        >
-      >,
-      Expect<
-        Equal<
-          Call<
-            Objects.PartialDeep,
-            WeakMap<{ key: string }, { value: boolean }>
-          >,
-          WeakMap<{ key?: string }, { value?: boolean }>
-        >
-      >,
-      Expect<Equal<Call<Objects.PartialDeep, Set<string>>, Set<string>>>,
-      Expect<
-        Equal<
-          Call<Objects.PartialDeep, Set<number[]>>,
-          Set<(number | undefined)[]>
-        >
-      >,
-      Expect<
-        Equal<
-          Call<Objects.PartialDeep, ReadonlySet<string>>,
-          ReadonlySet<string>
-        >
-      >,
-      Expect<Equal<Call<Objects.PartialDeep, []>, []>>,
-      Expect<Equal<Call<Objects.PartialDeep, never[]>, undefined[]>>,
-      Expect<
-        Equal<
-          Call<Objects.PartialDeep, [1, 2, 3]>,
-          [(1 | undefined)?, (2 | undefined)?, (3 | undefined)?]
-        >
-      >,
-      Expect<
-        Equal<
-          Call<Objects.PartialDeep, readonly number[]>,
-          readonly (number | undefined)[]
-        >
-      >,
-      Expect<
-        Equal<Call<Objects.PartialDeep, number[]>, (number | undefined)[]>
-      >,
-      Expect<
-        Equal<
-          Call<Objects.PartialDeep, Array<number>>,
-          Array<number | undefined>
-        >
-      >,
-      Expect<
-        Equal<Call<Objects.PartialDeep, Promise<number>>, Promise<number>>
-      >,
-      Expect<
-        Equal<
-          Call<
-            Objects.PartialDeep,
-            Promise<{ api: () => { play: () => void; pause: () => void } }>
-          >,
-          Promise<{ api?: () => { play: () => void; pause: () => void } }>
-        >
-      >,
-      Expect<
-        Equal<
-          Call<
-            Objects.PartialDeep,
-            {
-              readonly obj: unknown;
-              readonly arr: readonly unknown[];
-            }
-          >,
+          res7,
           {
             readonly obj?: unknown | undefined;
             readonly arr?: readonly unknown[] | undefined;
           }
         >
-      >,
-      Expect<
+      >;
+
+      type res8 = Call<Objects.PartialDeep, { a: 1; b: 2; c: 3 }>;
+      type test8 = Expect<Equal<res8, { a?: 1; b?: 2; c?: 3 }>>;
+
+      type res9 = Call<Objects.PartialDeep, { foo: () => void }>;
+      type test9 = Expect<Equal<res9, { foo?: () => void }>>;
+    });
+
+    it("Promises", () => {
+      type res0 = Call<Objects.PartialDeep, Promise<number>>;
+      type test0 = Expect<Equal<res0, Promise<number>>>;
+
+      type res1 = Call<
+        Objects.PartialDeep,
+        Promise<{ api: () => { play: () => void; pause: () => void } }>
+      >;
+      type test1 = Expect<
         Equal<
-          Call<Objects.PartialDeep, { a: 1; b: 2; c: 3 }>,
-          { a?: 1; b?: 2; c?: 3 }
+          res1,
+          Promise<{ api?: () => { play: () => void; pause: () => void } }>
         >
-      >,
-      Expect<
-        Equal<
-          Call<Objects.PartialDeep, { foo: () => void }>,
-          { foo?: () => void }
-        >
-      >,
-      Expect<
-        Equal<
-          Call<Objects.PartialDeep, ComplexNestedRequired>,
-          ComplexNestedPartial
-        >
-      >
-    ];
+      >;
+    });
+
+    it("Complex structures", () => {
+      type ComplexNestedRequired = {
+        simple: number;
+        nested: {
+          date: Date;
+          func: () => string;
+          array: { bar: number }[];
+          tuple: [string, number, { good: boolean }];
+          set: Set<{ name: string }>;
+          map: Map<
+            string,
+            {
+              name: string;
+            }
+          >;
+          promise: Promise<{ foo: string; bar: number }>;
+        };
+      };
+
+      type ComplexNestedPartial = {
+        simple?: number;
+        nested?: {
+          date?: Date;
+          func?: () => string;
+          array?: ({ bar?: number } | undefined)[];
+          set?: Set<{ name?: string }>;
+          tuple?: [string?, number?, { good?: boolean }?];
+          map?: Map<
+            string,
+            {
+              name?: string;
+            }
+          >;
+          promise?: Promise<{ foo?: string; bar?: number }>;
+        };
+      };
+
+      type res1 = Call<Objects.PartialDeep, ComplexNestedRequired>;
+      type test1 = Expect<Equal<res1, ComplexNestedPartial>>;
+    });
   });
 
   describe("Assign", () => {

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -95,47 +95,6 @@ describe("Objects", () => {
     });
   });
 
-  it("PartialDeep", () => {
-    type res0 = Call<Objects.PartialDeep, { a: 1; b: 2 }>;
-    //    ^?
-    type test0 = Expect<Equal<res0, { a?: 1; b?: 2 }>>;
-
-    type res1 = Call<Objects.PartialDeep, { a: 1; b: { c: 2 } }>;
-    //    ^?
-    type test1 = Expect<Equal<res1, { a?: 1; b?: { c?: 2 } }>>;
-
-    type res2 = Call<Objects.PartialDeep, { a: 1; b: { c: 2; d: { e: 3 } } }>;
-    //    ^?
-    type test2 = Expect<Equal<res2, { a?: 1; b?: { c?: 2; d?: { e?: 3 } } }>>;
-
-    type tuple = [string, number];
-    type res3 = Call<Objects.PartialDeep, tuple>;
-    //    ^?
-    type test3 = Expect<Equal<res3, [string?, number?]>>;
-
-    type res4 = Call<Objects.PartialDeep, [string, tuple]>;
-    //    ^?
-    type test4 = Expect<Equal<res4, [string?, [string?, number?]?]>>;
-
-    type res5 = Call<
-      Objects.PartialDeep,
-      { tuple: tuple; tuple2: { tuple3: tuple } }
-    >;
-    //    ^?
-    type test5 = Expect<
-      Equal<
-        res5,
-        { tuple?: [string?, number?]; tuple2?: { tuple3?: [string?, number?] } }
-      >
-    >;
-
-    type res6 = Call<Objects.PartialDeep, { tuple: [string, tuple] }>;
-    //    ^?
-    type test6 = Expect<
-      Equal<res6, { tuple?: [string?, [string?, number?]?] }>
-    >;
-  });
-
   describe("Update", () => {
     it("basic", () => {
       type res0 = Call<Objects.Update<"a", Numbers.Add<1>>, { a: 1; b: 1 }>;

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -301,6 +301,218 @@ describe("Objects", () => {
     type test1 = Expect<Equal<res1, { b: true }>>;
   });
 
+  it("PartialDeep", () => {
+    // interface ExtendedFunction extends Function {
+    //   args: 0;
+    // }
+
+    // interface ExtendedDate extends Date {
+    //   today(): number;
+    // }
+
+    // interface ExtendedError extends Error {
+    //   code: string;
+    // }
+
+    // interface ExtendedRegExp extends RegExp {
+    //   caseSensitive: true;
+    // }
+
+    type ComplexNestedRequired = {
+      simple: number;
+      nested: {
+        date: Date;
+        func: () => string;
+        array: { bar: number }[];
+        tuple: [string, number, { good: boolean }];
+        set: Set<{ name: string }>;
+        map: Map<
+          string,
+          {
+            name: string;
+          }
+        >;
+        promise: Promise<{ foo: string; bar: number }>;
+      };
+    };
+
+    type ComplexNestedPartial = {
+      simple?: number;
+      nested?: {
+        date?: Date;
+        func?: () => string;
+        array?: ({ bar?: number } | undefined)[];
+        set?: Set<{ name?: string }>;
+        tuple?: [string?, number?, { good?: boolean }?];
+        map?: Map<
+          string,
+          {
+            name?: string;
+          }
+        >;
+        promise?: Promise<{ foo?: string; bar?: number }>;
+      };
+    };
+
+    type cases = [
+      Expect<Equal<Call<Objects.PartialDeep, number>, number>>,
+      Expect<Equal<Call<Objects.PartialDeep, string>, string>>,
+      Expect<Equal<Call<Objects.PartialDeep, boolean>, boolean>>,
+      Expect<Equal<Call<Objects.PartialDeep, bigint>, bigint>>,
+      Expect<Equal<Call<Objects.PartialDeep, symbol>, symbol>>,
+      Expect<Equal<Call<Objects.PartialDeep, undefined>, undefined>>,
+      Expect<Equal<Call<Objects.PartialDeep, null>, null>>,
+      // Expect<Equal<Call<Objects.PartialDeep, Function>, Function>>,
+      // Expect<
+      //   Equal<
+      //     Call<Objects.PartialDeep, ExtendedFunction>,
+      //     Function & { args: 0 }
+      //   >
+      // >,
+      // Expect<Equal<Call<Objects.PartialDeep, Date>, Date>>,
+      // Expect<
+      //   Equal<
+      //     Call<Objects.PartialDeep, ExtendedDate>,
+      //     Date & { today(): number }
+      //   >
+      // >,
+      // Expect<Equal<Call<Objects.PartialDeep, Error>, Error>>,
+      // Expect<
+      //   Equal<
+      //     Call<Objects.PartialDeep, ExtendedError>,
+      //     Error & { code: string }
+      //   >
+      // >,
+      // Expect<Equal<Call<Objects.PartialDeep, RegExp>, RegExp>>,
+      // Expect<
+      //   Equal<
+      //     Call<Objects.PartialDeep, ExtendedRegExp>,
+      //     RegExp & { caseSensitive: true }
+      //   >
+      // >,
+      Expect<
+        Equal<
+          Call<Objects.PartialDeep, Map<string, boolean>>,
+          Map<string, boolean>
+        >
+      >,
+      Expect<
+        Equal<
+          Call<Objects.PartialDeep, Map<string, { a: number }>>,
+          Map<string, { a?: number }>
+        >
+      >,
+      Expect<
+        Equal<
+          Call<Objects.PartialDeep, ReadonlyMap<string, boolean>>,
+          ReadonlyMap<string, boolean>
+        >
+      >,
+      Expect<
+        Equal<
+          Call<Objects.PartialDeep, ReadonlyMap<string, { checked: boolean }>>,
+          ReadonlyMap<string, { checked?: boolean }>
+        >
+      >,
+      Expect<
+        Equal<
+          Call<Objects.PartialDeep, WeakMap<{ key: string }, boolean>>,
+          WeakMap<{ key?: string }, boolean>
+        >
+      >,
+      Expect<
+        Equal<
+          Call<
+            Objects.PartialDeep,
+            WeakMap<{ key: string }, { value: boolean }>
+          >,
+          WeakMap<{ key?: string }, { value?: boolean }>
+        >
+      >,
+      Expect<Equal<Call<Objects.PartialDeep, Set<string>>, Set<string>>>,
+      Expect<
+        Equal<
+          Call<Objects.PartialDeep, Set<number[]>>,
+          Set<(number | undefined)[]>
+        >
+      >,
+      Expect<
+        Equal<
+          Call<Objects.PartialDeep, ReadonlySet<string>>,
+          ReadonlySet<string>
+        >
+      >,
+      Expect<Equal<Call<Objects.PartialDeep, []>, []>>,
+      Expect<Equal<Call<Objects.PartialDeep, never[]>, undefined[]>>,
+      Expect<
+        Equal<
+          Call<Objects.PartialDeep, [1, 2, 3]>,
+          [(1 | undefined)?, (2 | undefined)?, (3 | undefined)?]
+        >
+      >,
+      Expect<
+        Equal<
+          Call<Objects.PartialDeep, readonly number[]>,
+          readonly (number | undefined)[]
+        >
+      >,
+      Expect<
+        Equal<Call<Objects.PartialDeep, number[]>, (number | undefined)[]>
+      >,
+      Expect<
+        Equal<
+          Call<Objects.PartialDeep, Array<number>>,
+          Array<number | undefined>
+        >
+      >,
+      Expect<
+        Equal<Call<Objects.PartialDeep, Promise<number>>, Promise<number>>
+      >,
+      Expect<
+        Equal<
+          Call<
+            Objects.PartialDeep,
+            Promise<{ api: () => { play: () => void; pause: () => void } }>
+          >,
+          Promise<{ api?: () => { play: () => void; pause: () => void } }>
+        >
+      >,
+      Expect<
+        Equal<
+          Call<
+            Objects.PartialDeep,
+            {
+              readonly obj: unknown;
+              readonly arr: readonly unknown[];
+            }
+          >,
+          {
+            readonly obj?: unknown | undefined;
+            readonly arr?: readonly unknown[] | undefined;
+          }
+        >
+      >,
+      Expect<
+        Equal<
+          Call<Objects.PartialDeep, { a: 1; b: 2; c: 3 }>,
+          { a?: 1; b?: 2; c?: 3 }
+        >
+      >,
+      Expect<
+        Equal<
+          Call<Objects.PartialDeep, { foo: () => void }>,
+          { foo?: () => void }
+        >
+      >,
+      Expect<
+        Equal<
+          Call<Objects.PartialDeep, ComplexNestedRequired>,
+          ComplexNestedPartial
+        >
+      >
+    ];
+  });
+
   describe("Assign", () => {
     it("can be called without any pre-filled arguments", () => {
       type res1 = Call<


### PR DESCRIPTION
**Summary**

Align type gaps for different structures:

- [x] Map/ReadonlyMap/WeakMap
- [x] Set/ReadonlySet/WeakSet
- [x] Promise
- [x] Unknown
- [x] Function/Date
- [ ] RegExp?
- [ ] Error?

**Why**

There are a lot of gaps in the implementation, I've covered all of them with tests

Let me know what happens with types that are extended (e.g. Error can be extended and usually people do that so I didn't include it in the list)