### PR TITLE
create `GetArg` type to simplify the `arg0`-`arg3` code in `Fn`

### DIFF
--- a/src/internals/core/Core.ts
+++ b/src/internals/core/Core.ts
@@ -4,6 +4,8 @@ import { Head } from "../helpers";
 declare const rawArgs: unique symbol;
 type rawArgs = typeof rawArgs;
 
+type GetArg<T extends Fn, Index extends number> = T[rawArgs] extends { [I in Index]: unknown } ? T[rawArgs][Index] : never
+
 /**
  * Base type for all functions
  * @description You need to extend this type to create a new function that can be used in the HOTScript library.
@@ -20,10 +22,10 @@ type rawArgs = typeof rawArgs;
 export interface Fn {
   [rawArgs]: unknown;
   args: this[rawArgs] extends infer args extends unknown[] ? args : never;
-  arg0: this[rawArgs] extends [infer arg, ...any] ? arg : never;
-  arg1: this[rawArgs] extends [any, infer arg, ...any] ? arg : never;
-  arg2: this[rawArgs] extends [any, any, infer arg, ...any] ? arg : never;
-  arg3: this[rawArgs] extends [any, any, any, infer arg, ...any] ? arg : never;
+  arg0: GetArg<this, 0>;
+  arg1: GetArg<this, 1>;
+  arg2: GetArg<this, 2>;
+  arg3: GetArg<this, 3>;
   return: unknown;
 }
 

--- a/src/internals/core/Core.ts
+++ b/src/internals/core/Core.ts
@@ -7,7 +7,7 @@ type rawArgs = typeof rawArgs;
 /**
  * Base type for all functions
  * @description You need to extend this type to create a new function that can be used in the HOTScript library.
- * usually you will just convert some typescript utility time you already have to a hotscript function.
+ * usually you will just convert some typescript utility type you already have to a hotscript function.
  * This way you can use the HOTScript library to create more complex functions.
  *
  * @example


### PR DESCRIPTION
i was trying to do something like this, but i don't think it's possible
```ts
export interface Fn {
  [rawArgs]: unknown;
  args: this[rawArgs] extends infer args extends unknown[] ? args : never;
  [Key in `arg${number}`]: GetArg<this, Key extends `arg${infer Index}` ? Index : never>
  return: unknown;
}
```