### PR TITLE
fix(TransformObjectDeep): remove `| undefined` in `Array` case

### DIFF
--- a/src/internals/objects/impl/objects.ts
+++ b/src/internals/objects/impl/objects.ts
@@ -86,7 +86,7 @@ export type TransformObjectDeep<fn extends Fn, type> = type extends
   : type extends Array<infer values>
   ? IsTuple<type> extends true
     ? Call<fn, { [Key in keyof type]: TransformObjectDeep<fn, type[Key]> }>
-    : Array<TransformObjectDeep<fn, values> | undefined>
+    : Array<TransformObjectDeep<fn, values>>
   : type extends Promise<infer value>
   ? Promise<TransformObjectDeep<fn, value>>
   : type extends object


### PR DESCRIPTION
Thank you so much for this library!
I am using it to patch deeply nested auto-generated types from https://github.com/payloadcms/payload.

Based on the name of a property, I am applying `Required<T>` for this property.

E.g: Transform
```ts
{
  x: {
    id?: string | undefined,
    ...
  },
  ...
}
```

to 

```ts
{
  x: {
    id: string,
    ...
  },
  ...
}
```

I only found the internal type `TransformObjectDeep` to help me with this use case.

```ts
import { type TransformObjectDeep } from 'hotscript/dist/internals/objects/impl/objects'
import { type SetRequired } from 'type-fest'

interface IdRequiredFn extends Fn {
  return: this['args'] extends [infer obj]
    ? obj extends { id?: string }
      ? SetRequired<obj, 'id'>
      : obj
    : never
}

type FixPayloadTypes<T> = TransformObjectDeep<
  ComposeLeft<[IdRequiredFn]>, // I am using other transform fns
  T
>
```

But by using `TransformObjectDeep` all properties with `Array<T>` type get "unioned" with `undefined`, causing access to the items to fail.
What is the reason for adding `undefined` to the type?