### PR TITLE
feat(String): RegExp `S.Replace`, `S.Match` and `S.MatchAll`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "jest": "^29.4.2",
         "prettier": "^2.8.4",
         "ts-jest": "^29.0.5",
-        "type-level-regexp": "^0.1.10",
+        "type-level-regexp": "^0.1.12",
         "typescript": "^4.9.5"
       }
     },
@@ -3434,9 +3434,9 @@
       }
     },
     "node_modules/type-level-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/type-level-regexp/-/type-level-regexp-0.1.10.tgz",
-      "integrity": "sha512-EIC9Y+hkLqL2z7GVWMN/z3R03/xIUJNc05xZGo+Q6cT8sePO77KO+QvLcxypn0snD3N5exO12prsP0GUQhhFxw==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/type-level-regexp/-/type-level-regexp-0.1.12.tgz",
+      "integrity": "sha512-8w8mTz1Cn4oIHXP41nrL+vUDV3PmXgvXqhXOYI5Dmx/4l3AELZsJbeED0WxkRF5g+rpORNLHa6s0+bub3KvUTQ==",
       "dev": true
     },
     "node_modules/typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "jest": "^29.4.2",
         "prettier": "^2.8.4",
         "ts-jest": "^29.0.5",
+        "type-level-regexp": "^0.1.10",
         "typescript": "^4.9.5"
       }
     },
@@ -3431,6 +3432,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/type-level-regexp": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/type-level-regexp/-/type-level-regexp-0.1.10.tgz",
+      "integrity": "sha512-EIC9Y+hkLqL2z7GVWMN/z3R03/xIUJNc05xZGo+Q6cT8sePO77KO+QvLcxypn0snD3N5exO12prsP0GUQhhFxw==",
+      "dev": true
     },
     "node_modules/typescript": {
       "version": "4.9.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "jest": "^29.4.2",
         "prettier": "^2.8.4",
         "ts-jest": "^29.0.5",
-        "type-level-regexp": "^0.1.12",
+        "type-level-regexp": "^0.1.13",
         "typescript": "^4.9.5"
       }
     },
@@ -3434,9 +3434,9 @@
       }
     },
     "node_modules/type-level-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/type-level-regexp/-/type-level-regexp-0.1.12.tgz",
-      "integrity": "sha512-8w8mTz1Cn4oIHXP41nrL+vUDV3PmXgvXqhXOYI5Dmx/4l3AELZsJbeED0WxkRF5g+rpORNLHa6s0+bub3KvUTQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/type-level-regexp/-/type-level-regexp-0.1.13.tgz",
+      "integrity": "sha512-nNq3nayYK6HUdPuhMTn+c/IMmxv7YsMgHHAOIJBo3nzPzrR0vlDgmAAloGQ+bU03xYNDyDLukBb9lh/fr4glog==",
       "dev": true
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jest": "^29.4.2",
     "prettier": "^2.8.4",
     "ts-jest": "^29.0.5",
+    "type-level-regexp": "^0.1.10",
     "typescript": "^4.9.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc src/index.ts -d --emitDeclarationOnly --outDir dist",
+    "build": "tsc -d --emitDeclarationOnly --outDir dist",
     "prepublishOnly": "npm run test && npm run build",
     "test": "jest",
     "clear-test": "jest --clearCache",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "jest": "^29.4.2",
     "prettier": "^2.8.4",
     "ts-jest": "^29.0.5",
-    "type-level-regexp": "^0.1.12",
+    "type-level-regexp": "^0.1.13",
     "typescript": "^4.9.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "jest": "^29.4.2",
     "prettier": "^2.8.4",
     "ts-jest": "^29.0.5",
-    "type-level-regexp": "^0.1.10",
+    "type-level-regexp": "^0.1.12",
     "typescript": "^4.9.5"
   }
 }

--- a/src/internals/strings/Strings.ts
+++ b/src/internals/strings/Strings.ts
@@ -1,11 +1,4 @@
-import {
-  Call,
-  ComposeLeft,
-  Fn,
-  PartialApply,
-  unset,
-  _,
-} from "../core/Core";
+import { Call, ComposeLeft, Fn, PartialApply, unset, _ } from "../core/Core";
 import { Std } from "../std/Std";
 import { Tuples } from "../tuples/Tuples";
 import * as H from "../helpers";

--- a/src/internals/strings/Strings.ts
+++ b/src/internals/strings/Strings.ts
@@ -1,5 +1,4 @@
 import {
-  Apply,
   Call,
   ComposeLeft,
   Fn,
@@ -146,7 +145,7 @@ export namespace Strings {
       infer Str,
       ...any
     ]
-      ? Apply<Impl.Match, [Str, RawRegExp]>
+      ? Call<Impl.Match, Str, RawRegExp>
       : never;
   }
 
@@ -172,7 +171,7 @@ export namespace Strings {
       infer Str,
       ...any
     ]
-      ? Apply<Impl.MatchAll, [Str, RawRegExp]>
+      ? Call<Impl.MatchAll, Str, RawRegExp>
       : never;
   }
 

--- a/src/internals/strings/Strings.ts
+++ b/src/internals/strings/Strings.ts
@@ -118,12 +118,14 @@ export namespace Strings {
   /**
    * Replace all instances of a substring in a string.
    * @param args[0] - The string to replace.
-   * @param from - The substring to replace.
-   * @param to - The substring to replace with.
+   * @param from - The substring to replace or a RegExp pattern (support `i` flag).
+   * @param to - The substring to replace with, can include special replacement patterns when replacing with a RegExp. see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement for more details.
    * @returns The replaced string.
    * @example
    * ```ts
    * type T0 = Call<Strings.Replace<".","/">,"a.b.c.d">; // "a/b/c/d"
+   * type T1 = Call<S.Replace<"/b(\\w+):\\s(?<year>\\d{4})/(?<month>\\d{1,2})/(?<day>\\d{1,2})/i", "My b$1 is $<month>.$<day>, $2">, "Birthday: 1991/9/15">; // "My birthday is 9.15, 1991"
+   * ```
    */
   export type Replace<
     from extends string | unset | _ = unset,

--- a/src/internals/strings/Strings.ts
+++ b/src/internals/strings/Strings.ts
@@ -1,4 +1,12 @@
-import { Call, ComposeLeft, Fn, PartialApply, unset, _ } from "../core/Core";
+import {
+  Apply,
+  Call,
+  ComposeLeft,
+  Fn,
+  PartialApply,
+  unset,
+  _,
+} from "../core/Core";
 import { Std } from "../std/Std";
 import { Tuples } from "../tuples/Tuples";
 import * as H from "../helpers";
@@ -112,6 +120,59 @@ export namespace Strings {
       ...any
     ]
       ? Impl.Trim<Str, Sep>
+      : never;
+  }
+
+  /**
+   * Match a string against a regular expression (support `i` and `g` flags).
+   * @param args[0] - The string to match.
+   * @param RawRegExp - The regular expression to match. Support both "/<pattern>/<flags>" or "<patttern>" syntax.
+   * @returns The matched object with match array and `index` and `groups` properties.
+   * ```ts
+   * type T0 = Call<S.Match<"/A(?<g1>[b-e]{1,2})F/i">, "12aBef34">; // ["aBef", "Be"] & { index: 2; groups: { g1: "Be" } }
+   * type T1 = Call<S.Match<"/a(?<g1>[b-e]{1,2})f/gi">, "12aBef34AeCf56">; // ["aBef", "AeCf"]
+   * ```
+   */
+  export type Match<
+    RawRegExp extends string | unset | _ = unset,
+    Str = unset
+  > = RawRegExp extends RawRegExp
+    ? PartialApply<MatchFn, [RawRegExp, Str]>
+    : never;
+
+  interface MatchFn extends Fn {
+    return: this["args"] extends [
+      infer RawRegExp extends string,
+      infer Str,
+      ...any
+    ]
+      ? Apply<Impl.Match, [Str, RawRegExp]>
+      : never;
+  }
+
+  /**
+   * Match a string against a regular expression, return an array of match objects.
+   * @param args[0] - The string to match.
+   * @param RawRegExp - The regular expression to match, `g` flag is required (also support `i` flag).
+   * @returns Array of matched object, each with a match array and `index` and `groups` properties.
+   * ```ts
+   * type T0 = Call<S.MatchAll<"/a(?<g1>[b-e]{1,2})f/gi">, "12aBef34AeCf56">; // [["aBef", "Be"] & { index: 2; groups: { g1: "Be"; }; }, ["AeCf", "eC"] & { index: 8; groups: { g1: "eC"; }; }]
+   * ```
+   */
+  export type MatchAll<
+    RawRegExp extends string | unset | _ = unset,
+    Str = unset
+  > = RawRegExp extends RawRegExp
+    ? PartialApply<MatchAllFn, [RawRegExp, Str]>
+    : never;
+
+  interface MatchAllFn extends Fn {
+    return: this["args"] extends [
+      infer RawRegExp extends string,
+      infer Str,
+      ...any
+    ]
+      ? Apply<Impl.MatchAll, [Str, RawRegExp]>
       : never;
   }
 

--- a/src/internals/strings/impl/match.ts
+++ b/src/internals/strings/impl/match.ts
@@ -1,0 +1,90 @@
+import { Call, Fn } from "../../core/Core";
+import { Split } from "../../helpers";
+import { T } from "../../..";
+
+import {
+  ParseRegExp,
+  MatchRegExp,
+  MatchAllRegExp,
+  Flag,
+} from "type-level-regexp/regexp";
+
+type SupportedRegExpReplaceFlags = "i" | "g" | "ig" | "gi";
+
+type PrettifyRegExpMatchArray<RegExpMatchResult> = RegExpMatchResult extends {
+  _matchArray: infer MatchArray;
+  index: infer Index;
+  groups: infer Groups;
+}
+  ? MatchArray & { index: Index; groups: Groups }
+  : null;
+
+interface PrettifyRegExpMatchArrayFn extends Fn {
+  return: this["args"] extends [infer RegExpMatchResult, ...any]
+    ? PrettifyRegExpMatchArray<RegExpMatchResult>
+    : never;
+}
+
+export interface Match extends Fn {
+  return: this["args"] extends [
+    infer Str extends string,
+    infer RawRegExp extends string,
+    ...any
+  ]
+    ? Str extends Str
+      ? RawRegExp extends `/${infer RegExp}/`
+        ? PrettifyRegExpMatchArray<MatchRegExp<Str, ParseRegExp<RegExp>, never>>
+        : RawRegExp extends `/${infer RegExp}/${SupportedRegExpReplaceFlags}`
+        ? RawRegExp extends `/${RegExp}/${infer Flags}`
+          ? Split<Flags, "">[number] extends infer FlagsUnion extends Flag
+            ? "g" extends FlagsUnion
+              ? MatchRegExp<Str, ParseRegExp<RegExp>, FlagsUnion>
+              : PrettifyRegExpMatchArray<
+                  MatchRegExp<Str, ParseRegExp<RegExp>, FlagsUnion>
+                >
+            : never
+          : never
+        : PrettifyRegExpMatchArray<
+            MatchRegExp<Str, ParseRegExp<RawRegExp>, never>
+          >
+      : never
+    : never;
+}
+
+export interface MatchAll extends Fn {
+  return: this["args"] extends [
+    infer Str extends string,
+    infer RawRegExp extends string,
+    ...any
+  ]
+    ? Str extends Str
+      ? RawRegExp extends `/${infer RegExp}/g`
+        ? MatchAllRegExp<Str, ParseRegExp<RegExp>, never> extends {
+            _matchedTuple: infer MatchTuple extends any[];
+          }
+          ? Call<T.Map<PrettifyRegExpMatchArrayFn>, MatchTuple>
+          : null
+        : RawRegExp extends `/${infer RegExp}/${Exclude<
+            SupportedRegExpReplaceFlags,
+            "i"
+          >}`
+        ? MatchAllRegExp<
+            Str,
+            ParseRegExp<RegExp>,
+            Split<
+              RawRegExp extends `/${RegExp}/${infer Flags extends SupportedRegExpReplaceFlags}`
+                ? Flags
+                : never,
+              ""
+            >[number]
+          > extends {
+            _matchedTuple: infer MatchTuple extends any[];
+          }
+          ? Call<T.Map<PrettifyRegExpMatchArrayFn>, MatchTuple>
+          : null
+        : TypeError & {
+            msg: "MatchAll called with a non-global RegExp argument";
+          }
+      : never
+    : never;
+}

--- a/src/internals/strings/impl/replace.ts
+++ b/src/internals/strings/impl/replace.ts
@@ -1,4 +1,9 @@
 import { Fn } from "../../core/Core";
+import { Split } from "../../helpers";
+
+import { ParseRegExp, ReplaceWithRegExp } from "type-level-regexp/regexp";
+
+type SupportedRegExpReplaceFlags = "i" | "g" | "ig" | "gi";
 
 export type Replace<
   Str,
@@ -16,6 +21,22 @@ export interface ReplaceReducer<To extends string> extends Fn {
     infer From extends string,
     ...any
   ]
-    ? Replace<Str, From, To>
+    ? Str extends Str
+      ? From extends `/${infer RegExp}/`
+        ? ReplaceWithRegExp<Str, ParseRegExp<RegExp>, To, never>
+        : From extends `/${infer RegExp}/${SupportedRegExpReplaceFlags}`
+        ? ReplaceWithRegExp<
+            Str,
+            ParseRegExp<RegExp>,
+            To,
+            Split<
+              From extends `/${RegExp}/${infer Flags extends SupportedRegExpReplaceFlags}`
+                ? Flags
+                : never,
+              ""
+            >[number]
+          >
+        : Replace<Str, From, To>
+      : never
     : never;
 }

--- a/src/internals/strings/impl/replace.ts
+++ b/src/internals/strings/impl/replace.ts
@@ -1,7 +1,12 @@
 import { Fn } from "../../core/Core";
 import { Split } from "../../helpers";
 
-import { ParseRegExp, ReplaceWithRegExp } from "type-level-regexp/regexp";
+import {
+  Flag,
+  Matcher,
+  ParseRegExp,
+  ReplaceWithRegExp,
+} from "type-level-regexp/regexp";
 
 type SupportedRegExpReplaceFlags = "i" | "g" | "ig" | "gi";
 
@@ -15,6 +20,16 @@ export type Replace<
     : Str
   : Str;
 
+type ResovleRegExpReplaceOrError<
+  Str extends string,
+  RegExp extends string,
+  To extends string,
+  FlagUnion extends Flag,
+  ParsedResult = ParseRegExp<RegExp>
+> = ParsedResult extends Matcher[]
+  ? ReplaceWithRegExp<Str, ParsedResult, To, FlagUnion>
+  : ParsedResult;
+
 export interface ReplaceReducer<To extends string> extends Fn {
   return: this["args"] extends [
     infer Str extends string,
@@ -23,11 +38,11 @@ export interface ReplaceReducer<To extends string> extends Fn {
   ]
     ? Str extends Str
       ? From extends `/${infer RegExp}/`
-        ? ReplaceWithRegExp<Str, ParseRegExp<RegExp>, To, never>
+        ? ResovleRegExpReplaceOrError<Str, RegExp, To, never>
         : From extends `/${infer RegExp}/${SupportedRegExpReplaceFlags}`
-        ? ReplaceWithRegExp<
+        ? ResovleRegExpReplaceOrError<
             Str,
-            ParseRegExp<RegExp>,
+            RegExp,
             To,
             Split<
               From extends `/${RegExp}/${infer Flags extends SupportedRegExpReplaceFlags}`

--- a/src/internals/strings/impl/strings.ts
+++ b/src/internals/strings/impl/strings.ts
@@ -1,5 +1,6 @@
 export * from "./split";
 export * from "./trim";
+export * from "./match";
 export * from "./replace";
 export * from "./repeat";
 export * from "./compare";

--- a/test/strings.test.ts
+++ b/test/strings.test.ts
@@ -105,6 +105,53 @@ describe("Strings", () => {
         Equal<res4, ["Cats", "coWs", "CAR", "cozY", "cOUch", "Comfort"]>
       >;
     });
+
+    it("return RegExp syntax errors and hints", () => {
+      type res5 = $<
+        //    ^?
+        Strings.Match<"/foo(b(ar)baz/">,
+        "basicRegExp_foobarbaz"
+      >;
+      type test5 = Expect<
+        Equal<
+          res5,
+          {
+            type: "RegExpSyntaxError";
+            message: "Invalid regular expression, missing closing `)`";
+          } & SyntaxError
+        >
+      >;
+
+      type res6 = $<
+        //    ^?
+        Strings.Match<"foo(?g1>bar)baz">,
+        "noWrapWith/_foobarbaz"
+      >;
+      type test6 = Expect<
+        Equal<
+          res6,
+          {
+            type: "RegExpSyntaxError";
+            message: "Invalid regular expression, invalid capture group name for capturing `bar`, possibly due to a missing opening '<' and group name";
+          } & SyntaxError
+        >
+      >;
+
+      type res7 = $<
+        //    ^?
+        Strings.Match<"/foo[a-zbar/g">,
+        "withFlag_fooabar"
+      >;
+      type test7 = Expect<
+        Equal<
+          res7,
+          {
+            type: "RegExpSyntaxError";
+            message: "Invalid regular expression, missing closing `]`";
+          } & SyntaxError
+        >
+      >;
+    });
   });
 
   describe("MatchAll", () => {
@@ -200,6 +247,53 @@ describe("Strings", () => {
         >
       >;
     });
+
+    it("return RegExp syntax errors and hints", () => {
+      type res5 = $<
+        //    ^?
+        Strings.MatchAll<"/foo(b(ar)baz/g">,
+        "basicRegExp_foobarbaz"
+      >;
+      type test5 = Expect<
+        Equal<
+          res5,
+          {
+            type: "RegExpSyntaxError";
+            message: "Invalid regular expression, missing closing `)`";
+          } & SyntaxError
+        >
+      >;
+
+      type res6 = $<
+        //    ^?
+        Strings.MatchAll<"/foo(?<g1bar)baz/g">,
+        "foobarbaz"
+      >;
+      type test6 = Expect<
+        Equal<
+          res6,
+          {
+            type: "RegExpSyntaxError";
+            message: "Invalid regular expression, invalid capture group name of `g1bar`, possibly due to a missing closing '>' for group name";
+          } & SyntaxError
+        >
+      >;
+
+      type res7 = $<
+        //    ^?
+        Strings.Match<"/foo?{2}bar/g">,
+        "fooabar"
+      >;
+      type test7 = Expect<
+        Equal<
+          res7,
+          {
+            type: "RegExpSyntaxError";
+            message: "Invalid regular expression, the preceding token to {2} is not quantifiable";
+          } & SyntaxError
+        >
+      >;
+    });
   });
 
   describe("Replace", () => {
@@ -283,6 +377,24 @@ describe("Strings", () => {
         Equal<
           res10,
           '<Card class="bg-primary"><MyTitle>HotScript X type-level RegExp!</MyTitle><MyCardContent><p>Type level madness.</p><MyActionBtn>READ MORE</MyActionBtn></MyCardContent></MyCard>'
+        >
+      >;
+    });
+
+    it("return RegExp syntax errors and hints", () => {
+      type res11 = $<
+        //    ^?
+        Strings.Replace<"/(foo)+*baz/">,
+        "foobarbaz",
+        "replace"
+      >;
+      type test11 = Expect<
+        Equal<
+          res11,
+          {
+            type: "RegExpSyntaxError";
+            message: "Invalid regular expression, the preceding token to * is not quantifiable";
+          } & SyntaxError
         >
       >;
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "ESNext",
+    "moduleResolution": "node",
     "declaration": true,
     "esModuleInterop": true,
     "target": "ESNext",


### PR DESCRIPTION
## Updates
1. Add [type-level-regexp](https://github.com/didavid61202/type-level-regexp) as dependency, and import helper types from a subpath export `type-level-regexp/regexp` to prevent global declaration side effects from the package.
3. Update `S.Replace` to also accept RegExp pattern (`/<pattern>/`) as `from` arg to replace substring matched by the given pattern. Replace value also support [special replacemnet patterns](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement).
4. add `S.Match` to match a string against a RegExp (support `i` and `g` flags), returns a matched object with match array and `index` and `groups` properties.
5. add `S.MatchAll` to match a string against a RegExp, return an array of match objects, each with a match array and `index` and `groups` properties.
6. `S.Replace`, `S.Match` and `S.MatchAll` all returns `RegExpSyntaxError` error type with detail error message when the provided RegExp contain Syntax error (currently only show few types of error, WIP)

## Note
I have kept the implementation of RegExp matching and replacing generic types in a separate package called type-level-regexp. This allows for faster iteration as it is still in the early stages, and more features and performance improvements are coming along the way.

## Usage
```ts
// Strings.Match exmaple
type MatchResult = Call<
        S.Match<"/a(?<g1>[b-e$]{1,4})\\W\\s\\b\\k<g1>(\\d+)/">,
        "12ab$c- b$c56#"
      >;
// type of `MatchResult` is:
// ["ab$c- b$c56", "b$c", "56"] & {
//   index: 2;
//   groups: {
//     g1: "b$c";
//   };
// }

// Strings.Replace exmaple
type ReplaceResult = Call<
//     ^? type ReplaceResult = "The release day is 2.13, 2023"
        S.Replace<
          "/((?:\\w|\\s)+):\\s(?<year>\\d{4})/(?<month>\\d{1,2})/(?<day>\\d{1,2})/",
          "The $1 is $<month>.$<day>, $2"
        >,
        "release day: 2023/2/13"
      >;

// RegExp syntax error exmaple
type SyntaxErrTest = Call<
        S.Match<"foo(?g1>bar)baz">,
        "foobarbaz"
      >;
// type of `SyntaxErrTest` is:
// {
//    type: "RegExpSyntaxError";
//    message: "Invalid regular expression, invalid capture group name for capturing `bar`, possibly due to a missing opening
//    '<' and group name";
// } & SyntaxError
```

## Related issues
Resolve #33

# Tasks
 - [x] add/update tests
 - [x] update JSDocs