### PR TITLE
feat(Tuples): add IndexOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ type ElementFromSelector<T> = H.Pipe<T, [
   - [x] `Last<Tuple>`: Returns the last element from a tuple.
   - [x] `FlatMap<Fn, Tuple>`: Calls an `Fn` function returning a tuple on each element of the input tuple, and flattens all of the returned tuples into a single one.
   - [x] `Find<Fn, Tuple>`: Finds an element from a tuple using a predicate `Fn`.
+  - [x] `IndexOf<X, Tuple>`: Returns the index of the first occurrence of a target value in a tuple.
   - [x] `Drop<N, Tuple>`: Drops the `N` first elements from a tuple.
   - [x] `Take<N, Tuple>`: Takes the `N` first elements from a tuple.
   - [x] `TakeWhile<Fn, Tuple>`: Take elements while the `Fn` predicate returns `true`.

--- a/src/internals/tuples/Tuples.ts
+++ b/src/internals/tuples/Tuples.ts
@@ -4,6 +4,7 @@ import {
   Apply,
   args,
   Call,
+  ComposeLeft,
   Fn,
   PartialApply,
   Pipe,
@@ -11,6 +12,7 @@ import {
   _,
 } from "../core/Core";
 import { Iterator, Prettify, Stringifiable } from "../helpers";
+import { Booleans } from "../booleans/Booleans";
 import { Objects } from "../objects/Objects";
 import * as NumberImpls from "../numbers/impl/numbers";
 import { Std } from "../std/Std";
@@ -375,6 +377,43 @@ export namespace Tuples {
   export interface FindFn extends Fn {
     return: FindImpl<this["arg1"], Extract<this["arg0"], Fn>>;
   }
+
+  type IndexOfImpl<target, tuple extends readonly unknown[]> = Call<
+    At<0>,
+    Call<
+      At<0>,
+      Call<
+        Filter<
+          ComposeLeft<[At<1>, Booleans.Equals<target>]>
+        >,
+        Call<
+          Zip,
+          Call<Range<0>, Call<Length, tuple>>,
+          tuple
+        >
+      >
+    >
+  >;
+  
+  interface IndexOfFn extends Fn {
+    return: IndexOfImpl<this["arg0"], this["arg1"]>;
+  }
+  
+  /**
+   * Returns the index of the first occurrence of a target value in a tuple.
+   * @param target - The target value to find.
+   * @param tuple - The tuple to search.
+   * @returns The index of the first occurrence of the value in the tuple.
+   * @example
+   * ```ts
+   * type a = Call<T.IndexOf<2, [1, 2, 3]>> // 1
+   * type b = Call<T.IndexOf<4, [1, 2, 3]>> // never
+   * ```
+   */
+  export type IndexOf<
+    target = unset,
+    tuple extends readonly unknown[] | unset = unset,
+  > = PartialApply<TupleIndexOfFn, [target, tuple]>;
 
   /**
    * Sum the elements of a tuple of numbers.


### PR DESCRIPTION
Hi,

It's my first contribution to this repo, so please feel free to let me know if it doesn't follow any formatting / linting stuffs.

Basically it works like this:

```ts
type a = Call<T.IndexOf<2, [1, 2, 3]>> // 1
type b = Call<T.IndexOf<4, [1, 2, 3]>> // never
```

And it's particularly useful to be used with `T.At`.